### PR TITLE
Oppdater no-narrative og LegemiddelKoder

### DIFF
--- a/LMDI/input/fsh/valuesets/lmdi-LegemiddelKoderValueSet.fsh
+++ b/LMDI/input/fsh/valuesets/lmdi-LegemiddelKoderValueSet.fsh
@@ -1,9 +1,12 @@
 ValueSet: LegemiddelKoder 
 Id: legemiddel-koder 
 Title: "Gyldige legemiddelkoder" 
-Description: "ValueSet som inneholder koder fra SNOMED CT og FEST" 
+Description: "ValueSet som inneholder koder fra SNOMED CT, FEST, LMR-nummer, varenummer og lokal legemiddelkatalog"
 * include codes from system http://snomed.info/sct
 * include codes from system http://dmp.no/fhir/NamingSystem/festLegemiddelMerkevare 
 * include codes from system http://dmp.no/fhir/NamingSystem/festLegemiddelVirkestoff 
 * include codes from system http://dmp.no/fhir/NamingSystem/festLegemiddelPakning 
 * include codes from system http://dmp.no/fhir/NamingSystem/festLegemiddelDose
+* include codes from system http://dmp.no/fhir/NamingSystem/lmrLopenummer
+* include codes from system http://dmp.no/fhir/NamingSystem/fest-varenummer
+* include codes from system http://fh.no/fhir/NamingSystem/lokaltVirkemiddel

--- a/LMDI/sushi-config.yaml
+++ b/LMDI/sushi-config.yaml
@@ -36,6 +36,17 @@ parameters:
   generate-json: true
   generate-xml: false
   generate-turtle: false
+  no-narrative:
+    - MedicationAdministration/*
+    - MedicationRequest/*
+    - Medication/*
+    - Patient/*
+    - Encounter/*
+    - Condition/*
+    - Organization/*
+    - Practitioner/*
+    - Substance/*
+    - Bundle/*
 dependencies:
   hl7.fhir.uv.extensions.r4: "5.2.0"
   hl7.fhir.no.basis: "2.2.0"
@@ -70,4 +81,3 @@ menu:
   Integrasjon: integrasjon.html
   FHIR-profiler: profiler.html
   Nedlastinger: nedlastinger.html
- 


### PR DESCRIPTION
## Endringer
- legger til `no-narrative`-parametere i `LMDI/sushi-config.yaml` for publiserte eksempelressurser
- utvider `LegemiddelKoder` i `LMDI/input/fsh/valuesets/lmdi-LegemiddelKoderValueSet.fsh` med `lmrLopenummer`, `fest-varenummer` og `lokaltVirkemiddel`
- oppdaterer ValueSet-beskrivelsen så den matcher faktisk innhold

## Verifisering
- SUSHI build verifisert lokalt med `fsh-sushi@3.18.1` og lokal `hl7.fhir.no.basis-2.2.0-snapshots.tgz`
- kontrollert at generert `ValueSet-legemiddel-koder.json` inneholder alle åtte systemene

## Ikke fullført
- full Publisher-build ble ikke kjørt til slutt, siden den tar lang tid i dette miljøet