### PR TITLE
Retter feil og inkonsistenser i FSH-profiler

### DIFF
--- a/LMDI/input/fsh/aliases.fsh
+++ b/LMDI/input/fsh/aliases.fsh
@@ -1,26 +1,8 @@
-// Standard FHIR aliases
-Alias: $v3-MaritalStatus = http://terminology.hl7.org/CodeSystem/v3-MaritalStatus
-Alias: $v2-0131 = http://terminology.hl7.org/CodeSystem/v2-0131
-Alias: $loinc = http://loinc.org
-Alias: $sct = http://snomed.info/sct
-Alias: $clinical-codes = http://acme.org/devices/clinical-codes
-Alias: $patient-citizenship = http://hl7.org/fhir/StructureDefinition/patient-citizenship
-Alias: $bcp13.txt = http://www.rfc-editor.org/bcp/bcp13.txt
-Alias: $v3-RoleCode = http://terminology.hl7.org/CodeSystem/v3-RoleCode
-
-// No-basis aliases (aktivert for no-basis support)
-Alias: $no-basis-family-relation = http://hl7.no/fhir/CodeSystem/no-basis-family-relation
-Alias: $no-basis-parental-responsibility = http://hl7.no/fhir/CodeSystem/no-basis-parental-responsibility
-Alias: $no-basis-marital-status = http://hl7.no/fhir/CodeSystem/no-basis-marital-status
-Alias: $no-basis-conferencetype = http://hl7.no/fhir/structuredefinition/no-basis-conferencetype
-Alias: $no-basis-group = http://hl7.no/fhir/structuredefinition/no-basis-appointment/no-basis-group
-Alias: $no-basis-partof = http://hl7.no/fhir/structuredefinition/no-basis-appointment/no-basis-partof
-Alias: $no-basis-postponementreason = https://example.org/fhir/structuredefinition/no-basis-postponementreason
+// No-basis aliases
 Alias: NoBasisPatient = http://hl7.no/fhir/StructureDefinition/no-basis-Patient
 Alias: NoBasisAddress = http://hl7.no/fhir/StructureDefinition/no-basis-Address
 Alias: NoBasisOrganization = http://hl7.no/fhir/StructureDefinition/no-basis-Organization
 Alias: NoBasisSubstance = http://hl7.no/fhir/StructureDefinition/no-basis-Substance
-Alias: NoBasisPropertyInformation = http://hl7.no/fhir/StructureDefinition/no-basis-propertyinformation
 Alias: $VsLmdiUrbanDistrict = urn:oid:2.16.578.1.12.4.1.1.3403
 Alias: $kommunenummer-alle = urn:oid:2.16.578.1.12.4.1.1.3402
 Alias: $organization-type = http://terminology.hl7.org/CodeSystem/organization-type

--- a/LMDI/input/fsh/extensions/lmdi-ext-del-av-behandlingsregime.fsh
+++ b/LMDI/input/fsh/extensions/lmdi-ext-del-av-behandlingsregime.fsh
@@ -2,4 +2,6 @@ Extension: DelAvBehandlingsregime
 Id: lmdi-del-av-behandlingsregime
 Title: "Del av behandlingsregime"
 Description: "Navnet på kuren, behandlingsregimet eller protokollen legemidlet gis som en del av. Spesielt relevant ved kjemoterapi."
+* ^context.type = #element
+* ^context.expression = "MedicationRequest"
 * value[x] only string

--- a/LMDI/input/fsh/extensions/lmdi-ext-klinisk-studie.fsh
+++ b/LMDI/input/fsh/extensions/lmdi-ext-klinisk-studie.fsh
@@ -2,4 +2,6 @@ Extension: KliniskStudie
 Id: lmdi-klinisk-studie
 Title: "Klinisk studie"
 Description: "Angir om legemidlet gis som en del av en klinisk studie."
+* ^context.type = #element
+* ^context.expression = "MedicationRequest"
 * value[x] only boolean

--- a/LMDI/input/fsh/extensions/lmdi-ext-prosentvis-doseendring.fsh
+++ b/LMDI/input/fsh/extensions/lmdi-ext-prosentvis-doseendring.fsh
@@ -2,6 +2,8 @@ Extension: ProsentvisDoseendring
 Id: lmdi-prosentvis-doseendring
 Title: "Prosentvis doseendring"
 Description: "Doseendring i prosent, sammenlignet med opprinnelig dosering. Spesielt relevant ved kjemoterapi."
+* ^context.type = #element
+* ^context.expression = "MedicationRequest"
 * value[x] only Quantity
 * valueQuantity.system = "http://unitsofmeasure.org"
 * valueQuantity.code = #%

--- a/LMDI/input/fsh/namingsystems/lmdi-lokaltVirkemiddel.fsh
+++ b/LMDI/input/fsh/namingsystems/lmdi-lokaltVirkemiddel.fsh
@@ -10,7 +10,7 @@ Usage: #definition
 * publisher = "Folkehelseinstituttet"
 * responsible = "Folkehelseinstituttet"
 * description = "Id for angivelse av legemiddel fra lokal legemiddelkatalog"
-* jurisdiction = urn:iso:std:iso:3166#NO "Norway - Ditt Prosjekt"
+* jurisdiction = urn:iso:std:iso:3166#NO "Norway"
 * uniqueId[0].type = #uri
 * uniqueId[=].value = "http://fh.no/fhir/NamingSystem/lokaltVirkemiddel"
 * uniqueId[=].preferred = true

--- a/LMDI/input/fsh/profiles/LegemiddelregisterBundle.fsh
+++ b/LMDI/input/fsh/profiles/LegemiddelregisterBundle.fsh
@@ -56,7 +56,7 @@ Instance: LegemiddelregisterBundle-1
 InstanceOf: LegemiddelregisterBundle
 Usage: #example
 Title: "Eksempel på LegemiddelregisterBundle med administreringer"
-Description: "Eksempel på en batch-bundle som inneholder to legemiddeladministreringer"
+Description: "Eksempel på en transaction-bundle som inneholder to legemiddeladministreringer"
 
 * identifier.system = "urn:oid:2.16.578.1.34.10.3"
 * identifier.value = "bundle-001"

--- a/LMDI/input/fsh/profiles/lmdi-Condition.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-Condition.fsh
@@ -22,6 +22,7 @@ Description: "Diagnosen som pasienten har fått rekvirert eller administrert leg
 * asserter 0..0
 * evidence 0..0
 * note 0..0
+* stage.summary 1..1
 * stage.assessment 0..0
 
 // Grunnleggende elementer
@@ -76,9 +77,6 @@ Description: "Diagnosen som pasienten har fått rekvirert eller administrert leg
 * code.coding[ICPC2].code 1..1
 * code.coding[ICPC2].code ^short = "Diagnosekode fra kodeverket"
 * code.coding[ICPC2].display ^short = "Beskrivelse av diagnosekode (fra kodeverket)"
-
-* stage ^constraint[0].expression = ""
-* stage ^constraint[0].severity = #warning
 
 // EKSEMPLER
 Instance: Diagnose-1-ICD10-OID

--- a/LMDI/input/fsh/profiles/lmdi-Medication.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-Medication.fsh
@@ -7,6 +7,7 @@ Description: "Beskrivelse av legemiddel."
 * ^date = "2025-09-30"
 * ^publisher = "Folkehelseinstituttet"
 
+* obeys lmdi-medication-code-or-ingredient
 * manufacturer 0..0
 * text 0..0
 
@@ -76,9 +77,9 @@ Description: "Beskrivelse av legemiddel."
 * extension ^slicing.discriminator.type = #value
 * extension ^slicing.discriminator.path = "url"
 * extension ^slicing.rules = #closed
-* extension contains LegemiddelClassification named classification 0..*
-* extension[classification] ^short = "Klassifisering av legemidlet, fortrinnsvis ved bruk av ATC-kode fra WHO ATC kodesystem. Ett legemiddel kan ha inntil én ATC-kode."
-* extension[classification] ^definition = "Klassifisering av legemidlet, fortrinnsvis ved bruk av ATC-kode fra WHO ATC kodesystem. Ett legemiddel kan ha inntil én ATC-kode."
+* extension contains LegemiddelClassification named classification 0..1
+* extension[classification] ^short = "Klassifisering av legemidlet ved bruk av ATC-kode fra WHO ATC kodesystem. Ett legemiddel kan ha inntil én ATC-kode."
+* extension[classification] ^definition = "Klassifisering av legemidlet ved bruk av ATC-kode fra WHO ATC kodesystem. Ett legemiddel kan ha inntil én ATC-kode."
 * extension[classification] ^comment = "Denne extension brukes for å angi legemidlets klassifisering i henhold til standardiserte kodesystemer, primært ATC-koder fra WHO."
 
 * form.text 0..0
@@ -91,7 +92,6 @@ Description: "Beskrivelse av legemiddel."
 * form.coding ^slicing.discriminator.path = "system"
 * form.coding ^slicing.rules = #closed
 * form.coding contains OID7448 0..1 and SCT 0..1
-* form.coding 1..* 
 * form.coding ^short = "Legemiddelform"
 * form.coding ^comment = "Kodet legemiddelform. Inntil videre begrenset til Legemiddelform (OID: 7448) og kodesetteksempel fra HL7 basert på SNOMED CT."
 * form.coding[OID7448] ^short = "Kodeverk Legemiddelform (OID:7448) fra FEST"
@@ -131,7 +131,7 @@ Description: "Eksempel på legemiddel"
 
 Instance: Medisin-2-Paracetamol
 InstanceOf: Legemiddel
-Description: "Eksempel på legemiddel - Paracetamol - UTKAST"
+Description: "Eksempel på legemiddel - Paracetamol"
 * identifier.system = "http://dmp.no/fhir/NamingSystem/festLegemiddelMerkevare"
 * identifier.value = "2ABAC272-0BCF-43F0-84BE-984074D92E15"
 * extension[classification].valueCodeableConcept = $ATC#N02BE01 "Paracetamol"
@@ -154,3 +154,9 @@ Description: "Eksempel på legemiddel - paking"
 * form.coding[OID7448].system = "urn:oid:2.16.578.1.12.4.1.1.7448"
 * form.coding[OID7448].code = #68
 * form.coding[OID7448].display = "Depottablett"
+
+// Invarianter
+Invariant: lmdi-medication-code-or-ingredient
+Description: "Medication skal ha code.coding eller ingredient"
+Severity: #error
+Expression: "code.coding.exists() or ingredient.exists()"

--- a/LMDI/input/fsh/profiles/lmdi-MedicationAdministration.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-MedicationAdministration.fsh
@@ -57,16 +57,19 @@ Dette er kjerneressursen for denne implementasjonsguiden. Den peker videre til l
 * dosage.route.coding ^slicing.discriminator.type = #pattern
 * dosage.route.coding ^slicing.discriminator.path = "system"
 * dosage.route.coding ^slicing.rules = #closed
+* dosage.route.coding 1..*
 * dosage.route.coding contains SCT 0..1 and OID7477 0..1
 
 * dosage.route.coding[SCT] ^short = "SNOMED CT"
 * dosage.route.coding[SCT] ^definition = "Administrasjonsvei kodet med SNOMED CT, hentet fra verdisett foreslått av HL7."
 * dosage.route.coding[SCT].system = "http://snomed.info/sct"
+* dosage.route.coding[SCT].code 1..1
 * dosage.route.coding[SCT].code from http://hl7.org/fhir/ValueSet/route-codes (required)
 
 * dosage.route.coding[OID7477] ^short = "Administrasjonsvei (OID=7477)"
 * dosage.route.coding[OID7477] ^definition = "Administrasjonsvei (OID=7477) fra kodeverkssamling Resept."
 * dosage.route.coding[OID7477].system = "urn:oid:2.16.578.1.12.4.1.1.7477"
+* dosage.route.coding[OID7477].code 1..1
 * dosage.route.coding[OID7477].code ^short = "Verdi fra kodeverket"
 * dosage.route.coding[OID7477].display ^short = "Beskrivelse av koden (navn) fra kodeverket"
 
@@ -102,12 +105,11 @@ ValueSet: LegemiddeladministreringStatus
 Id: lmdi-medicationadministrationstatus
 Title: "Status for legemiddeladministrering"
 Description: "Verdisett som begrenses status til Legemiddeladministrering til henholdsvis 'Gjennomført' eller 'Feilregistrert'."
-* ^version = "1.0.6"
 * ^status = #draft
 * ^date = "2025-09-12"
 * ^publisher = "Folkehelseinstituttet"
-* http://hl7.org/fhir/ValueSet/medication-admin-status#completed "Gjennomført"
-* http://hl7.org/fhir/ValueSet/medication-admin-status#entered-in-error "Feilregistrert"
+* http://terminology.hl7.org/CodeSystem/medication-admin-status#completed "Gjennomført"
+* http://terminology.hl7.org/CodeSystem/medication-admin-status#entered-in-error "Feilregistrert"
 
 // =========================================
 // Examples
@@ -123,10 +125,10 @@ Description: "Eksempel på administrering av legemiddel"
 * dosage.route.coding[SCT].system = "http://snomed.info/sct"
 * dosage.route.coding[SCT].code = #421521009
 * dosage.route.coding[SCT].display = "Swallow"
-* dosage.dose.value = 2.0
-* dosage.dose.unit = "metric tablespoon"
+* dosage.dose.value = 10.0
+* dosage.dose.unit = "ml"
 * dosage.dose.system = "http://unitsofmeasure.org"
-* dosage.dose.code = #tsp_us
+* dosage.dose.code = #mL
 
 Instance: Administrering-2-Infusjon
 InstanceOf: Legemiddeladministrering
@@ -146,7 +148,7 @@ Description: "Eksempel på administrering av legemiddel - infusjon"
 * dosage.dose.code = #mg
 * dosage.rateRatio.numerator.value = 8.0
 * dosage.rateRatio.numerator.system = "http://unitsofmeasure.org"
-* dosage.rateRatio.numerator.code = #ml
+* dosage.rateRatio.numerator.code = #mL
 * dosage.rateRatio.denominator.value = 1
 * dosage.rateRatio.denominator.system = "http://unitsofmeasure.org"
 * dosage.rateRatio.denominator.code = #min

--- a/LMDI/input/fsh/profiles/lmdi-MedicationRequest.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-MedicationRequest.fsh
@@ -75,7 +75,7 @@ Description: "Legemiddelrekvirering - ordinering eller annen rekvirering av lege
 * encounter only Reference(Episode)
 * encounter ^short = "Episoden (f.eks. konsultasjonen/innleggelsen) som legemidlet ble rekvirert i forbindelse med."
 
-* courseOfTherapyType ^short = "continuous | acute | seasonal"
+* courseOfTherapyType ^short = "Type behandlingsforløp (continuous | acute | seasonal)"
 
 // Andre elementer
 * reported[x] only boolean
@@ -87,7 +87,7 @@ Description: "Legemiddelrekvirering - ordinering eller annen rekvirering av lege
 Instance: Rekvirering-1
 InstanceOf: Legemiddelrekvirering
 Description: "Eksempel på legemiddelrekvirering av Paracet"
-* identifier.system = "urn:oid:2.16.578.1.12.4.1.1.reseptid"
+* identifier.system = "http://example.org/rekvirering-id"
 * identifier.value = "REK123456"
 * status = #active
 * intent = #order

--- a/LMDI/input/fsh/profiles/lmdi-Organization.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-Organization.fsh
@@ -15,7 +15,6 @@ Det er ønskelig at minimum følgende inngår i "organisasjonshierarkiet":
      - sykehjem, kommune
 - minst ett organisasjonsnummer fra enten Enhetsregisteret (identifier:ENH) eller Register for enheter i spesialisthelsetjenesten (identifier:RSH)
 """
-* ^version = "1.0.7"
 * ^status = #draft
 * ^date = "2025-09-30"
 * ^publisher = "Folkehelseinstituttet"
@@ -89,7 +88,6 @@ Description: "Eksempel på sykehjem i primærhelsetjenesten"
 * identifier[ENH].system = "urn:oid:2.16.578.1.12.4.1.4.101"
 * identifier[ENH].value = "1234567890"
 * name = "Lykkedalen sykehjem"
-// Midlertidig fjernet type for testing - kan legges tilbake med no-basis slices
 * address.type = #physical
 * address.district = "Sigdal"
 * address.district.extension[municipalitycode].valueCoding = $kommunenummer-alle#3025 "Sigdal"

--- a/LMDI/input/fsh/profiles/lmdi-Patient.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-Patient.fsh
@@ -42,7 +42,6 @@ Description: "Pasienten som har fått rekvirert eller administrert legemiddel, b
 * address.use ^binding.description = "Tillatte verdier er home, temp eller old"
 * address.use ^short = "home | temp | old"
 * address.use ^definition = "Adressetype begrenset til home, temp eller old"
-* address.use obeys address-use-constraint
 * address.state ^short = "Fylkesnavn"
 * address.country 0..0
 * address.postalCode 0..0
@@ -62,7 +61,7 @@ Description: "Pasienten som har fått rekvirert eller administrert legemiddel, b
 // Identifikatorer - bruker no-basis slices
 * identifier MS
 * identifier ^short = "Identifikator for pasienten."
-* identifier ^definition = "Identifikator for pasienten. Skal være fødselsnummer (FNR) eller D-nummer (DNR)."
+* identifier ^definition = "Identifikator for pasienten. Bør være fødselsnummer (FNR) eller D-nummer (DNR) når tilgjengelig."
 
 // Bruker no-basis sine eksisterende slices
 * identifier[FNR] 0..1 MS
@@ -103,8 +102,4 @@ Description: "Eksempel på pasient med fødselsnummer"
 * address.district.extension[municipalitycode].valueCoding = $kommunenummer-alle#3024 "Bærum"
 
 
-Invariant: address-use-constraint
-Description: "Kun home, temp eller old er tillatt for address.use"
-Severity: #error
-Expression: "address.use.empty() or address.use in ('home' | 'temp' | 'old')"
 

--- a/LMDI/input/fsh/profiles/lmdi-Practitioner.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-Practitioner.fsh
@@ -7,7 +7,6 @@ Description: "Helsepersonell som har rekvirert legemidlet, basert på no-basis-P
 * ^status = #draft
 * ^date = "2025-09-12"
 * ^publisher = "Folkehelseinstituttet"
-* ^version = "1.0.6"
 
 // === IDENTIFIER HÅNDTERING ===
 // Bruker no-basis slicing med closed slicing for å begrense til kun HPR

--- a/LMDI/input/fsh/valuesets/lmdi-LokalLegemiddelKatalogValues.fsh
+++ b/LMDI/input/fsh/valuesets/lmdi-LokalLegemiddelKatalogValues.fsh
@@ -6,5 +6,5 @@ Description: "Kodesystem for lokal legemiddelkatalog"
 
 ValueSet: LokalLegemiddelkatalogValues
 Title: "Lokal Legemiddelkatalog Values"
-Description: "Gyldige verdier for medlemskapsstatus"
+Description: "Gyldige verdier for lokal legemiddelkatalog"
 * include codes from system LokalLegemiddelkatalogCodeSystem


### PR DESCRIPTION
## Sammendrag

Systematisk gjennomgang og retting av feil, inkonsistenser og mangler i FSH-profilene. Endringene er prioritert etter alvorlighetsgrad (P0–P2) og verifisert med SUSHI (0 errors, 0 warnings).

## P0 — Feilrettinger

### Feil CodeSystem-URL i LegemiddeladministreringStatus
`lmdi-MedicationAdministration.fsh` — ValueSet-et brukte `http://hl7.org/fhir/ValueSet/medication-admin-status` (en ValueSet-URL) som system for koder. Rettet til korrekt CodeSystem-URL: `http://terminology.hl7.org/CodeSystem/medication-admin-status`.

### Tom constraint-overstyring på Condition.stage
`lmdi-Condition.fsh` — Linje 80–81 overstyrte base-constrainten `con-1` med et tomt uttrykk, noe som i praksis slo av valideringen "stage skal ha summary eller assessment". Hacket er fjernet og erstattet med `stage.summary 1..1`, som oppfyller `con-1` korrekt når `stage.assessment` er `0..0`.

### Manglende extension context på tre MedicationRequest-extensions
`lmdi-ext-del-av-behandlingsregime.fsh`, `lmdi-ext-klinisk-studie.fsh`, `lmdi-ext-prosentvis-doseendring.fsh` — Disse manglet eksplisitt `^context`, og ble dermed generert som globale Element-extensions. Lagt til `^context.type = #element` og `^context.expression = "MedicationRequest"` på alle tre.

### Sprik mellom tekst og modell for Medication.extension:classification
`lmdi-Medication.fsh` — Teksten sa "inntil én ATC-kode", men kardinaliteten var `0..*`. Rettet til `0..1`. Fjernet "fortrinnsvis" fra beskrivelsen da ATC er eneste tillatte kodesystem.

### Manglende invariant for code-or-ingredient
`lmdi-Medication.fsh` — Regelen "code.coding eller ingredient må ha verdi" sto bare i tekst. Lagt til håndhevbar invariant: `lmdi-medication-code-or-ingredient` med expression `code.coding.exists() or ingredient.exists()`.

## P1 — Forbedringer

### Innstramming av dosage.route
`lmdi-MedicationAdministration.fsh` — Lagt til `dosage.route.coding 1..*` og `code 1..1` på begge slices (SCT og OID7477), slik at route-koding faktisk håndheves når route er angitt.

### Redundant address-use-constraint fjernet
`lmdi-Patient.fsh` — Invarianten `address-use-constraint` var redundant med den required binding til `LmdiAddressUse`. I tillegg var FHIRPath-uttrykket feil (brukte `address.use` i stedet for `$this` i konteksten til `address.use`-elementet). Slettet invarianten helt.

### Hardkodede artefaktversjoner fjernet
`lmdi-Practitioner.fsh` (`1.0.6`), `lmdi-Organization.fsh` (`1.0.7`), `lmdi-MedicationAdministration.fsh` ValueSet (`1.0.6`) — Fjernet hardkodede `^version`-felt slik at `sushi-config.yaml` (v1.0.8) styrer versjonering konsistent.

### Hygiene- og copy-paste-feil rettet
- `lmdi-lokaltVirkemiddel.fsh`: Plassholder "Norway - Ditt Prosjekt" → "Norway"
- `lmdi-LokalLegemiddelKatalogValues.fsh`: Feil beskrivelse "medlemskapsstatus" → "lokal legemiddelkatalog"
- `LegemiddelregisterBundle.fsh`: "batch-bundle" → "transaction-bundle"
- `lmdi-Medication.fsh`: Fjernet "UTKAST" fra eksempelbeskrivelse
- `lmdi-Organization.fsh`: Fjernet "Midlertidig fjernet type for testing"-kommentar

### Eksempler rettet
- `lmdi-MedicationRequest.fsh`: Ugyldig OID `urn:oid:...reseptid` → `http://example.org/rekvirering-id`
- `lmdi-MedicationAdministration.fsh`: Inkonsistent UCUM — `unit="metric tablespoon"` med `code=#tsp_us` → 10 mL med korrekt `#mL`
- `lmdi-MedicationAdministration.fsh`: UCUM `#ml` → `#mL` (case-sensitive) i infusjonseksempel

### Patient.identifier tekst myknet
`lmdi-Patient.fsh` — Definisjonen sa "Skal være FNR eller DNR" mens modellen tillater ingen identifier. Endret til "Bør være fødselsnummer (FNR) eller D-nummer (DNR) når tilgjengelig".

### courseOfTherapyType beskrivelse forbedret
`lmdi-MedicationRequest.fsh` — Endret fra bare verdiliste til "Type behandlingsforløp (continuous | acute | seasonal)".

## P2 — Rydding

### Ubrukte aliaser fjernet
`aliases.fsh` — 16 ubrukte aliaser fjernet (bl.a. `$v3-MaritalStatus`, `$loinc`, `$clinical-codes`, alle `$no-basis-*`-aliaser, `NoBasisPropertyInformation`). Kun aliaser som faktisk brukes i profilene er beholdt.

### Duplisert form.coding fjernet
`lmdi-Medication.fsh` — `form.coding 1..*` var definert to ganger (linje 86 og 94). Fjernet duplikatet.

## Verifisering

- SUSHI v3.18.1: **0 Errors, 0 Warnings**
- 14 filer endret, 34 linjer lagt til, 48 linjer fjernet

## Gjenstående designvurderinger (utenfor scope)

- Bundle-invarianten `lr-allowed-resources` krever `meta.profile` på alle ressurser — bør dokumenteres eksplisitt hvis tilsiktet
- Extension-IDer (`legemiddel-classification`, `npr-episode-identifier`) mangler `lmdi-`-prefiks, men endring er breaking change og bør vurderes separat