### PR TITLE
Forkort instansnavn for IG Publisher pakkelengde

### DIFF
--- a/LMDI/input/fsh/examples/lmdi-example-botox-intramuskular.fsh
+++ b/LMDI/input/fsh/examples/lmdi-example-botox-intramuskular.fsh
@@ -1,6 +1,6 @@
 // Eksempel: intramuskular administrering med paknings-id og varenummer
 
-Instance: Legemiddeladministrering-Eksempel-Botox-Intramuskular
+Instance: Administrering-Eksempel-Botox-Intramuskular
 InstanceOf: Legemiddeladministrering
 Usage: #example
 Description: "Eksempel med intramuskular administrering av Botox og legemiddelreferanse med FEST paknings-id."

--- a/LMDI/input/fsh/examples/lmdi-example-logisk-referanse-infusjon.fsh
+++ b/LMDI/input/fsh/examples/lmdi-example-logisk-referanse-infusjon.fsh
@@ -1,7 +1,7 @@
 // Eksempel: infusjon med logisk referanse
 // Demonstrerer bruk av identifier-referanser i stedet for literal-referanser
 
-Instance: Legemiddeladministrering-Eksempel-LogiskReferanse-Infusjon
+Instance: Administrering-Eksempel-LogiskReferanse-Infusjon
 InstanceOf: Legemiddeladministrering
 Usage: #example
 Description: "Eksempel med logisk medikamentreferanse ved infusjon, uten lokal medication-ressurs i meldingen."

--- a/LMDI/input/fsh/examples/lmdi-example-scenario-kjemoterapi.fsh
+++ b/LMDI/input/fsh/examples/lmdi-example-scenario-kjemoterapi.fsh
@@ -79,7 +79,7 @@ Description: "Lokalregistrert oksaliplatin med ingredient-reference og ATC-klass
 * ingredient.itemReference = Reference(Virkestoff-Scenario-Kjemoterapi-Full-Oksaliplatin)
 * ingredient.isActive = true
 
-Instance: Legemiddelrekvirering-Scenario-Kjemoterapi-Full-Forrige
+Instance: Rekvirering-Scenario-Kjemoterapi-Full-Forrige
 InstanceOf: Legemiddelrekvirering
 Usage: #example
 Description: "Tidligere rekvirering i samme kurforløp."
@@ -96,7 +96,7 @@ Description: "Tidligere rekvirering i samme kurforløp."
 * reportedBoolean = false
 * courseOfTherapyType.text = "Kjemoterapikur"
 
-Instance: Legemiddelrekvirering-Scenario-Kjemoterapi-Full-Gjeldende
+Instance: Rekvirering-Scenario-Kjemoterapi-Full-Gjeldende
 InstanceOf: Legemiddelrekvirering
 Usage: #example
 Description: "Aktiv rekvirering i FOLFOX6-regime med alle LMDI-extensions."
@@ -109,7 +109,7 @@ Description: "Aktiv rekvirering i FOLFOX6-regime med alle LMDI-extensions."
 * requester = Reference(Helsepersonell-Scenario-Kjemoterapi-Full-Rekvirent)
 * encounter = Reference(Episode-Scenario-Kjemoterapi-Full-Innleggelse)
 * reasonReference = Reference(Diagnose-Scenario-Kjemoterapi-Full-Kreftdiagnose)
-* priorPrescription = Reference(Legemiddelrekvirering-Scenario-Kjemoterapi-Full-Forrige)
+* priorPrescription = Reference(Rekvirering-Scenario-Kjemoterapi-Full-Forrige)
 * authoredOn = "2025-03-10"
 * reportedBoolean = false
 * courseOfTherapyType.text = "Kjemoterapikur"
@@ -120,7 +120,7 @@ Description: "Aktiv rekvirering i FOLFOX6-regime med alle LMDI-extensions."
 * extension[delAvBehandlingsregime].valueString = "FOLFOX6"
 * extension[kliniskStudie].valueBoolean = true
 
-Instance: Legemiddeladministrering-Scenario-Kjemoterapi-Full-Oksaliplatin
+Instance: Administrering-Scenario-Kjemoterapi-Full-Oksaliplatin
 InstanceOf: Legemiddeladministrering
 Usage: #example
 Description: "Infusjon av lokalregistrert oksaliplatin med request-, diagnose- og hastighetsinformasjon."
@@ -128,7 +128,7 @@ Description: "Infusjon av lokalregistrert oksaliplatin med request-, diagnose- o
 * medicationReference = Reference(Legemiddel-Scenario-Kjemoterapi-Full-Oksaliplatin-LokalKatalog)
 * subject = Reference(Pasient-Scenario-Kjemoterapi-Full-Med-FNR)
 * context = Reference(Episode-Scenario-Kjemoterapi-Full-Innleggelse)
-* request = Reference(Legemiddelrekvirering-Scenario-Kjemoterapi-Full-Gjeldende)
+* request = Reference(Rekvirering-Scenario-Kjemoterapi-Full-Gjeldende)
 * reasonReference = Reference(Diagnose-Scenario-Kjemoterapi-Full-Kreftdiagnose)
 * effectivePeriod.start = "2025-03-10T09:00:00+01:00"
 * effectivePeriod.end = "2025-03-10T11:00:00+01:00"
@@ -187,14 +187,14 @@ Description: "Komplett bundle som viser lokal legemiddelkatalog, diagnosekobling
 * entry[6].request.method = #POST
 * entry[6].request.url = "Medication"
 
-* entry[7].resource = Legemiddelrekvirering-Scenario-Kjemoterapi-Full-Forrige
+* entry[7].resource = Rekvirering-Scenario-Kjemoterapi-Full-Forrige
 * entry[7].request.method = #POST
 * entry[7].request.url = "MedicationRequest"
 
-* entry[8].resource = Legemiddelrekvirering-Scenario-Kjemoterapi-Full-Gjeldende
+* entry[8].resource = Rekvirering-Scenario-Kjemoterapi-Full-Gjeldende
 * entry[8].request.method = #POST
 * entry[8].request.url = "MedicationRequest"
 
-* entry[9].resource = Legemiddeladministrering-Scenario-Kjemoterapi-Full-Oksaliplatin
+* entry[9].resource = Administrering-Scenario-Kjemoterapi-Full-Oksaliplatin
 * entry[9].request.method = #POST
 * entry[9].request.url = "MedicationAdministration"

--- a/LMDI/input/fsh/examples/lmdi-example-scenario-rekvirering.fsh
+++ b/LMDI/input/fsh/examples/lmdi-example-scenario-rekvirering.fsh
@@ -1,7 +1,7 @@
 // Scenario: Endosebasert smertebehandling med rekvirering og diagnose
 // Demonstrerer: D-nummer, diagnosekobling, FestLmrLopenr- og Varenummer-slicer, samt begge route-slicer
 
-Instance: Pasient-Scenario-Endose-Smertebehandling-Med-DNR
+Instance: Pasient-Scenario-Smertebehandling-Med-DNR
 InstanceOf: Pasient
 Usage: #example
 Description: "Pasient med D-nummer i et innleggelsesscenario for postoperativ smertebehandling."
@@ -12,14 +12,14 @@ Description: "Pasient med D-nummer i et innleggelsesscenario for postoperativ sm
 * address.district = "Bergen"
 * address.district.extension[municipalitycode].valueCoding = $kommunenummer-alle#4601 "Bergen"
 
-Instance: Helsepersonell-Scenario-Endose-Smertebehandling-Rekvirent
+Instance: Helsepersonell-Scenario-Smertebehandling-Rekvirent
 InstanceOf: Helsepersonell
 Usage: #example
 Description: "Rekvirerende lege i sykehusscenarioet."
 * identifier[HPR].system = "urn:oid:2.16.578.1.12.4.1.4.4"
 * identifier[HPR].value = "7654321"
 
-Instance: Organisasjon-Scenario-Endose-Smertebehandling-Sykehus
+Instance: Organisasjon-Scenario-Smertebehandling-Sykehus
 InstanceOf: Organisasjon
 Usage: #example
 Description: "Sykehusorganisasjon der behandling og administrering skjer."
@@ -32,20 +32,20 @@ Description: "Sykehusorganisasjon der behandling og administrering skjer."
 * address.district = "Bergen"
 * address.district.extension[municipalitycode].valueCoding = $kommunenummer-alle#4601 "Bergen"
 
-Instance: Episode-Scenario-Endose-Smertebehandling-Innleggelse
+Instance: Episode-Scenario-Smertebehandling-Innleggelse
 InstanceOf: Episode
 Usage: #example
 Description: "Sykehusinnleggelse for pasient med akutt smertebehov."
 * status = #finished
 * class = http://terminology.hl7.org/CodeSystem/v3-ActCode#IMP "inpatient encounter"
-* serviceProvider = Reference(Organisasjon-Scenario-Endose-Smertebehandling-Sykehus)
+* serviceProvider = Reference(Organisasjon-Scenario-Smertebehandling-Sykehus)
 * extension[nprEpisodeIdentifier].extension[stringIdentifier].valueString = "NPR-HUS-2025-4567"
 
-Instance: Diagnose-Scenario-Endose-Smertebehandling-Postoperativ-Smerte
+Instance: Diagnose-Scenario-Smertebehandling-Postoperativ-Smerte
 InstanceOf: Diagnose
 Usage: #example
 Description: "Postoperativ smerte kodet med både ICD-10 og SNOMED CT."
-* subject = Reference(Pasient-Scenario-Endose-Smertebehandling-Med-DNR)
+* subject = Reference(Pasient-Scenario-Smertebehandling-Med-DNR)
 * stage.summary.text = "Akutt postoperativ smerte"
 * code.coding[ICD10].system = "urn:oid:2.16.578.1.12.4.1.1.7110"
 * code.coding[ICD10].code = #G89.1
@@ -54,7 +54,7 @@ Description: "Postoperativ smerte kodet med både ICD-10 og SNOMED CT."
 * code.coding[SCT].code = #274663001
 * code.coding[SCT].display = "Acute pain (finding)"
 
-Instance: Legemiddel-Scenario-Endose-Smertebehandling-Morfin-Endose
+Instance: Legemiddel-Scenario-Smertebehandling-Morfin-Endose
 InstanceOf: Legemiddel
 Usage: #example
 Description: "Morfin identifisert med både LMR-løpenummer og varenummer."
@@ -69,29 +69,29 @@ Description: "Morfin identifisert med både LMR-løpenummer og varenummer."
 * form.coding[OID7448].code = #11
 * form.coding[OID7448].display = "Injeksjonsvæske, oppløsning"
 
-Instance: Legemiddelrekvirering-Scenario-Endose-Smertebehandling-Morfin
+Instance: Rekvirering-Scenario-Smertebehandling-Morfin
 InstanceOf: Legemiddelrekvirering
 Usage: #example
 Description: "Rekvirering av morfin ved postoperativ smerte."
 * status = #completed
 * intent = #order
-* medicationReference = Reference(Legemiddel-Scenario-Endose-Smertebehandling-Morfin-Endose)
-* subject = Reference(Pasient-Scenario-Endose-Smertebehandling-Med-DNR)
-* requester = Reference(Helsepersonell-Scenario-Endose-Smertebehandling-Rekvirent)
+* medicationReference = Reference(Legemiddel-Scenario-Smertebehandling-Morfin-Endose)
+* subject = Reference(Pasient-Scenario-Smertebehandling-Med-DNR)
+* requester = Reference(Helsepersonell-Scenario-Smertebehandling-Rekvirent)
 * authoredOn = "2025-03-09"
-* reasonReference = Reference(Diagnose-Scenario-Endose-Smertebehandling-Postoperativ-Smerte)
-* encounter = Reference(Episode-Scenario-Endose-Smertebehandling-Innleggelse)
+* reasonReference = Reference(Diagnose-Scenario-Smertebehandling-Postoperativ-Smerte)
+* encounter = Reference(Episode-Scenario-Smertebehandling-Innleggelse)
 
-Instance: Legemiddeladministrering-Scenario-Endose-Smertebehandling-Morfin
+Instance: Administrering-Scenario-Smertebehandling-Morfin
 InstanceOf: Legemiddeladministrering
 Usage: #example
 Description: "Subkutan administrering med både SNOMED- og OID7477-koding av administrasjonsvei."
 * status = #completed
-* medicationReference = Reference(Legemiddel-Scenario-Endose-Smertebehandling-Morfin-Endose)
-* subject = Reference(Pasient-Scenario-Endose-Smertebehandling-Med-DNR)
-* context = Reference(Episode-Scenario-Endose-Smertebehandling-Innleggelse)
-* request = Reference(Legemiddelrekvirering-Scenario-Endose-Smertebehandling-Morfin)
-* reasonReference = Reference(Diagnose-Scenario-Endose-Smertebehandling-Postoperativ-Smerte)
+* medicationReference = Reference(Legemiddel-Scenario-Smertebehandling-Morfin-Endose)
+* subject = Reference(Pasient-Scenario-Smertebehandling-Med-DNR)
+* context = Reference(Episode-Scenario-Smertebehandling-Innleggelse)
+* request = Reference(Rekvirering-Scenario-Smertebehandling-Morfin)
+* reasonReference = Reference(Diagnose-Scenario-Smertebehandling-Postoperativ-Smerte)
 * effectiveDateTime = "2025-03-09T22:30:00+01:00"
 * dosage.dose.value = 5.0
 * dosage.dose.unit = "mg"
@@ -104,7 +104,7 @@ Description: "Subkutan administrering med både SNOMED- og OID7477-koding av adm
 * dosage.route.coding[OID7477].code = #3
 * dosage.route.coding[OID7477].display = "Subkutan"
 
-Instance: Bundle-Scenario-Endose-Smertebehandling
+Instance: Bundle-Scenario-Smertebehandling
 InstanceOf: LegemiddelregisterBundle
 Usage: #example
 Title: "Endosebasert smertebehandling med rekvirering, diagnose og administrering"
@@ -114,34 +114,34 @@ Description: "Komplett bundle for postoperativ smertebehandling der legemidlet e
 * timestamp = "2025-03-10T08:00:00+01:00"
 * type = #transaction
 
-* entry[0].resource = Pasient-Scenario-Endose-Smertebehandling-Med-DNR
+* entry[0].resource = Pasient-Scenario-Smertebehandling-Med-DNR
 * entry[0].request.method = #POST
 * entry[0].request.url = "Patient"
 
-* entry[1].resource = Helsepersonell-Scenario-Endose-Smertebehandling-Rekvirent
+* entry[1].resource = Helsepersonell-Scenario-Smertebehandling-Rekvirent
 * entry[1].request.method = #POST
 * entry[1].request.url = "Practitioner"
 
-* entry[2].resource = Organisasjon-Scenario-Endose-Smertebehandling-Sykehus
+* entry[2].resource = Organisasjon-Scenario-Smertebehandling-Sykehus
 * entry[2].request.method = #POST
 * entry[2].request.url = "Organization"
 
-* entry[3].resource = Episode-Scenario-Endose-Smertebehandling-Innleggelse
+* entry[3].resource = Episode-Scenario-Smertebehandling-Innleggelse
 * entry[3].request.method = #POST
 * entry[3].request.url = "Encounter"
 
-* entry[4].resource = Diagnose-Scenario-Endose-Smertebehandling-Postoperativ-Smerte
+* entry[4].resource = Diagnose-Scenario-Smertebehandling-Postoperativ-Smerte
 * entry[4].request.method = #POST
 * entry[4].request.url = "Condition"
 
-* entry[5].resource = Legemiddel-Scenario-Endose-Smertebehandling-Morfin-Endose
+* entry[5].resource = Legemiddel-Scenario-Smertebehandling-Morfin-Endose
 * entry[5].request.method = #POST
 * entry[5].request.url = "Medication"
 
-* entry[6].resource = Legemiddelrekvirering-Scenario-Endose-Smertebehandling-Morfin
+* entry[6].resource = Rekvirering-Scenario-Smertebehandling-Morfin
 * entry[6].request.method = #POST
 * entry[6].request.url = "MedicationRequest"
 
-* entry[7].resource = Legemiddeladministrering-Scenario-Endose-Smertebehandling-Morfin
+* entry[7].resource = Administrering-Scenario-Smertebehandling-Morfin
 * entry[7].request.method = #POST
 * entry[7].request.url = "MedicationAdministration"

--- a/LMDI/input/fsh/examples/lmdi-example-scenario-sykehjem-oksykodon.fsh
+++ b/LMDI/input/fsh/examples/lmdi-example-scenario-sykehjem-oksykodon.fsh
@@ -55,7 +55,7 @@ Description: "Legemiddel med FEST dose-id og SNOMED-koding."
 * form.coding[OID7448].code = #51
 * form.coding[OID7448].display = "Mikstur, oppløsning"
 
-Instance: Legemiddelrekvirering-Scenario-Sykehjem-Oksykodon-Oral
+Instance: Rekvirering-Scenario-Sykehjem-Oksykodon-Oral
 InstanceOf: Legemiddelrekvirering
 Usage: #example
 Description: "Rekvirering av oksykodon i sykehjemsscenarioet."
@@ -67,7 +67,7 @@ Description: "Rekvirering av oksykodon i sykehjemsscenarioet."
 * encounter = Reference(Episode-Scenario-Sykehjem-Oksykodon-Opphold)
 * authoredOn = "2024-05-28T12:30:00+02:00"
 
-Instance: Legemiddeladministrering-Scenario-Sykehjem-Oksykodon-Oral
+Instance: Administrering-Scenario-Sykehjem-Oksykodon-Oral
 InstanceOf: Legemiddeladministrering
 Usage: #example
 Description: "Oral administrering av oksykodon med referanser til egne relaterte ressurser."
@@ -75,7 +75,7 @@ Description: "Oral administrering av oksykodon med referanser til egne relaterte
 * medicationReference = Reference(Legemiddel-Scenario-Sykehjem-Oksykodon-FEST-Dose)
 * subject = Reference(Pasient-Scenario-Sykehjem-Oksykodon-Med-FNR)
 * context = Reference(Episode-Scenario-Sykehjem-Oksykodon-Opphold)
-* request = Reference(Legemiddelrekvirering-Scenario-Sykehjem-Oksykodon-Oral)
+* request = Reference(Rekvirering-Scenario-Sykehjem-Oksykodon-Oral)
 * effectiveDateTime = "2024-05-28T13:14:00+02:00"
 * dosage.dose.value = 5.0
 * dosage.dose.unit = "mg"

--- a/LMDI/input/fsh/examples/lmdi-example-scenario-sykehjem.fsh
+++ b/LMDI/input/fsh/examples/lmdi-example-scenario-sykehjem.fsh
@@ -58,7 +58,7 @@ Description: "Minimumsscenario - oksykodon identifisert med FEST virkestoff-id."
 * code.coding[FestVirkestoff].code = #C31AF94A-5D5A-4C91-9B99-BB221E26E4C9
 * code.coding[FestVirkestoff].display = "Oksykodon"
 
-Instance: Legemiddeladministrering-Scenario-Sykehjem-Minimum-Paracetamol
+Instance: Administrering-Scenario-Sykehjem-Minimum-Paracetamol
 InstanceOf: Legemiddeladministrering
 Usage: #example
 Description: "Minimumsscenario - tablettadministrering uten valgfri kontekst utover episode."
@@ -72,7 +72,7 @@ Description: "Minimumsscenario - tablettadministrering uten valgfri kontekst uto
 * dosage.dose.system = "http://unitsofmeasure.org"
 * dosage.dose.code = #mg
 
-Instance: Legemiddeladministrering-Scenario-Sykehjem-Minimum-Oksykodon
+Instance: Administrering-Scenario-Sykehjem-Minimum-Oksykodon
 InstanceOf: Legemiddeladministrering
 Usage: #example
 Description: "Minimumsscenario - administrering av oksykodon som virkestoffidentifisert legemiddel."
@@ -124,10 +124,10 @@ Description: "Transaction-bundle med kun nødvendige felter, organisasjonshierar
 * entry[6].request.method = #POST
 * entry[6].request.url = "Medication"
 
-* entry[7].resource = Legemiddeladministrering-Scenario-Sykehjem-Minimum-Paracetamol
+* entry[7].resource = Administrering-Scenario-Sykehjem-Minimum-Paracetamol
 * entry[7].request.method = #POST
 * entry[7].request.url = "MedicationAdministration"
 
-* entry[8].resource = Legemiddeladministrering-Scenario-Sykehjem-Minimum-Oksykodon
+* entry[8].resource = Administrering-Scenario-Sykehjem-Minimum-Oksykodon
 * entry[8].request.method = #POST
 * entry[8].request.url = "MedicationAdministration"

--- a/LMDI/input/fsh/profiles/LegemiddelregisterBundle.fsh
+++ b/LMDI/input/fsh/profiles/LegemiddelregisterBundle.fsh
@@ -84,10 +84,10 @@ Description: "Eksempel på transaction-bundle der relaterte ressurser sendes som
 * entry[4].request.method = #POST
 * entry[4].request.url = "Medication"
 
-* entry[5].resource = Legemiddelrekvirering-Scenario-Sykehjem-Oksykodon-Oral
+* entry[5].resource = Rekvirering-Scenario-Sykehjem-Oksykodon-Oral
 * entry[5].request.method = #POST
 * entry[5].request.url = "MedicationRequest"
 
-* entry[6].resource = Legemiddeladministrering-Scenario-Sykehjem-Oksykodon-Oral
+* entry[6].resource = Administrering-Scenario-Sykehjem-Oksykodon-Oral
 * entry[6].request.method = #POST
 * entry[6].request.url = "MedicationAdministration"

--- a/LMDI/input/fsh/profiles/lmdi-MedicationAdministration.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-MedicationAdministration.fsh
@@ -114,7 +114,7 @@ Description: "Verdisett som begrenses status til Legemiddeladministrering til he
 // =========================================
 // Examples
 // =========================================
-Instance: Legemiddeladministrering-Eksempel-Oral
+Instance: Administrering-Eksempel-Oral
 InstanceOf: Legemiddeladministrering
 Description: "Eksempel på administrering av legemiddel"
 * status = #completed
@@ -130,7 +130,7 @@ Description: "Eksempel på administrering av legemiddel"
 * dosage.dose.system = "http://unitsofmeasure.org"
 * dosage.dose.code = #mg
 
-Instance: Legemiddeladministrering-Eksempel-Infusjon
+Instance: Administrering-Eksempel-Infusjon
 InstanceOf: Legemiddeladministrering
 Description: "Eksempel på administrering av legemiddel - infusjon"
 * status = #completed

--- a/LMDI/input/fsh/profiles/lmdi-MedicationRequest.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-MedicationRequest.fsh
@@ -84,7 +84,7 @@ Description: "Legemiddelrekvirering - ordinering eller annen rekvirering av lege
 //  priorPrescription må referere til Legemiddelrekvirering
 
 // EKSEMPEL
-Instance: Legemiddelrekvirering-Eksempel-Paracetamol
+Instance: Rekvirering-Eksempel-Paracetamol
 InstanceOf: Legemiddelrekvirering
 Description: "Eksempel på legemiddelrekvirering av Paracet"
 * identifier.system = "http://example.org/rekvirering-id"
@@ -96,7 +96,7 @@ Description: "Eksempel på legemiddelrekvirering av Paracet"
 * requester = Reference(Helsepersonell-Eksempel-Med-HPR)
 * authoredOn = "2025-01-27"
 
-Instance: Legemiddelrekvirering-Eksempel-Kjemoterapi
+Instance: Rekvirering-Eksempel-Kjemoterapi
 InstanceOf: Legemiddelrekvirering
 Description: "Eksempel på kjemoterapirekvirering med doseendring, behandlingsregime og klinisk studie"
 * status = #active


### PR DESCRIPTION
## Summary
- Forkorter instansprefikser for aa holde filstier i IG Publisher-pakken under 100 bytes
- `Legemiddeladministrering-` → `Administrering-` (sparer 10 tegn)
- `Legemiddelrekvirering-` → `Rekvirering-` (sparer 10 tegn)
- `Endose-Smertebehandling` → `Smertebehandling` som scenarionavn (sparer 7 tegn)

Bakgrunn: IG Publisher bruker tar-format med 100-byte grense paa filnavn inkludert `package/example/`-prefix. Kombinasjonen av FHIR-ressurstype (f.eks. `MedicationAdministration`) og fullt norsk profilnavn overskred grensen.

## Test plan
- [ ] Verifiser at IG Publisher bygger uten "file name too long"-feil
- [ ] Sjekk at `sushi .` kompilerer uten feil

🤖 Generated with [Claude Code](https://claude.com/claude-code)