### PR TITLE
Presiser dokumentasjon for NPR episodeidentifikator

### DIFF
--- a/LMDI/input/fsh/extensions/lmdi-ext-npr-episode-identifier.fsh
+++ b/LMDI/input/fsh/extensions/lmdi-ext-npr-episode-identifier.fsh
@@ -1,7 +1,7 @@
 Extension: NprEpisodeIdentifier
 Id: npr-episode-identifier
 Title: "NPR Episode Identifier"
-Description: "Entydig identifikator for episode, brukt ved rapportering til NPR. Kan inneholde både string-basert og UUID-basert identifikator."
+Description: "Entydig identifikator for episode som skal sendes til LMDI. Extensionen kan bære både string-basert og UUID-basert representasjon av den valgte NPR-identifikatoren. Forretningsregelen for LMDI er at kun én NPR-identifikator skal sendes per episode. Selv om helseinstitusjonens systemer kan ha flere NPR-identifiere for samme episode lokalt, skal kun én velges ved innsending - gjerne den første eller foretrukne identifikatoren lokalt."
 * ^context.type = #element
 * ^context.expression = "Encounter"
 * ^status = #active
@@ -10,13 +10,13 @@ Description: "Entydig identifikator for episode, brukt ved rapportering til NPR.
     stringIdentifier 0..1 MS and
     uuidIdentifier 0..1 MS
 
-* extension[stringIdentifier] ^short = "String-basert NPR episode identifikator"
-* extension[stringIdentifier] ^definition = "String-basert identifikator for episoden som brukes ved rapportering til NPR."
+* extension[stringIdentifier] ^short = "String-representasjon av NPR episodeidentifikatoren"
+* extension[stringIdentifier] ^definition = "String-representasjon av den valgte NPR episodeidentifikatoren som sendes til LMDI. Skal oppgis dersom stringrepresentasjonen av identifikatoren er tilgjengelig."
 * extension[stringIdentifier].value[x] only string
 * extension[stringIdentifier].valueString 1..1
 
-* extension[uuidIdentifier] ^short = "UUID-basert NPR episode identifikator"
-* extension[uuidIdentifier] ^definition = "UUID-basert identifikator for episoden som brukes ved rapportering til NPR."
+* extension[uuidIdentifier] ^short = "UUID-representasjon av NPR episodeidentifikatoren"
+* extension[uuidIdentifier] ^definition = "UUID-representasjon av den valgte NPR episodeidentifikatoren som sendes til LMDI. Skal oppgis dersom UUID-representasjonen av identifikatoren er tilgjengelig."
 * extension[uuidIdentifier].value[x] only uuid
 * extension[uuidIdentifier].valueUuid 1..1
 

--- a/LMDI/input/fsh/profiles/lmdi-Encounter.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-Encounter.fsh
@@ -5,8 +5,8 @@ Title: "Episode"
 Description: "Profil for en behandlingsepisode basert på Encounter-ressursen i FHIR. Denne profilen representerer et klinisk møte eller en behandling i helsevesenet, med fokus på organisatorisk tilhørighet."
 
 * extension contains NprEpisodeIdentifier named nprEpisodeIdentifier 0..1 MS
-* extension[nprEpisodeIdentifier] ^short = "Unik identifikator(er) for episoden, som brukes ved rapportering til NPR"
-* extension[nprEpisodeIdentifier] ^definition = "En eller flere unike identifikatorer (string og/eller UUID) som identifiserer episoden entydig i helseinstitusjonens systemer. Brukes ved rapportering til Norsk pasientregister (NPR). Kan inneholde både string-basert og UUID-basert identifikator samtidig."
+* extension[nprEpisodeIdentifier] ^short = "NPR episodeidentifikator som sendes til LMDI"
+* extension[nprEpisodeIdentifier] ^definition = "Unik identifikator for episoden som skal sendes til LMDI. Selv om helseinstitusjonens systemer kan ha flere NPR-identifiere for samme episode lokalt, skal kun én NPR-identifikator angis ved innsending til LMDI. Dersom flere identifiere finnes, velges gjerne den første eller foretrukne identifikatoren lokalt. Den valgte identifikatoren skal oppgis med sin string-representasjon og/eller UUID-representasjon dersom begge er tilgjengelig."
 
 * statusHistory 0..0 
 * classHistory 0..0


### PR DESCRIPTION
## Sammendrag

Oppdaterer dokumentasjonen for NPR episodeidentifikator i både profilen og extensionen for å tydeliggjøre at:
- Selv om en helseinstitusjon kan ha flere NPR-identifiere for samme episode lokalt
- Skal kun **én** NPR-identifikator angis ved innsending til LMDI
- Dersom flere identifiere finnes lokalt, velges gjerne den første eller foretrukne identifikatoren

## Endringer

- **lmdi-Encounter.fsh**: Oppdatert ^short og ^definition for extension[nprEpisodeIdentifier]
- **lmdi-ext-npr-episode-identifier.fsh**: Oppdatert Description og ^short/^definition for begge slicene (stringIdentifier og uuidIdentifier)

Strukturen, cardinaliteter og invarianter er bevart uendret.

## Testplan

- Verifiser at dokumentasjonen er klar og konsistent mellom profil og extension
- Verifiser at SUSHI kompilerer uten feil: `cd LMDI && sushi .`

Løser #52

🤖 Generert med [Claude Code](https://claude.com/claude-code)