### PR TITLE
Oppdater definisjon av nprEpisodeIdentifier

### DIFF
--- a/LMDI/input/fsh/profiles/lmdi-Encounter.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-Encounter.fsh
@@ -6,7 +6,7 @@ Description: "Profil for en behandlingsepisode basert på Encounter-ressursen i 
 
 * extension contains NprEpisodeIdentifier named nprEpisodeIdentifier 0..1 MS
 * extension[nprEpisodeIdentifier] ^short = "NPR episodeidentifikator som sendes til LMDI"
-* extension[nprEpisodeIdentifier] ^definition = "Unik identifikator for episoden som skal sendes til LMDI. Selv om helseinstitusjonens systemer kan ha flere NPR-identifiere for samme episode lokalt, skal kun én NPR-identifikator angis ved innsending til LMDI. Dersom flere identifiere finnes, velges gjerne den første eller foretrukne identifikatoren lokalt. Den valgte identifikatoren skal oppgis med sin string-representasjon og/eller UUID-representasjon dersom begge er tilgjengelig."
+* extension[nprEpisodeIdentifier] ^definition = "Unik identifikator for episoden som skal sendes til LMDI. Selv om avsender kan ha flere NPR-identifiere for samme episode lokalt, skal kun én NPR-identifikator angis ved innsending til LMDI. Dersom flere identifiere finnes, velges gjerne den første eller foretrukne identifikatoren lokalt. Den valgte identifikatoren skal oppgis med sin string-representasjon og/eller UUID-representasjon dersom begge er tilgjengelig."
 
 * statusHistory 0..0 
 * classHistory 0..0


### PR DESCRIPTION
## Bakgrunn
Definisjonen av `Encounter.extension:nprEpisodeIdentifier` hadde en upresist formulering som refererte til "helseinstitusjonens systemer". For større klarhet er denne endret til "avsender".

## Endringer
- Erstattet "helseinstitusjonens systemer" med "avsender" i definisjonen av `extension[nprEpisodeIdentifier]` i Episode-profilen