### PR TITLE
Legg til lmdi-fhir skill med FSH-snapshot og vedlikeholdsscript

### DIFF
--- a/.claude/skills/lmdi-fhir/SKILL.md
+++ b/.claude/skills/lmdi-fhir/SKILL.md
@@ -5,20 +5,22 @@ description: Oppdatert arbeidsnotat for LMDI FHIR-profiler. Bruk denne når du s
 
 # LMDI FHIR-profiler
 
-Bruk denne skillen for LMDI-repoet (rotmappen i dette repoet).
+Bruk denne skillen for LMDI FHIR Implementation Guide.
 
 ## Arbeidsmåte
 
-Bruk denne kildeprioriteten:
+Denne skillen er self-contained for lesing og oppslag. Alle FSH-kilder finnes som snapshot under `references/` i skill-mappen. Bruk denne kildeprioriteten:
 
-1. `LMDI/sushi-config.yaml` for gjeldende versjon, canonical, dato og dependencies
-2. `LMDI/input/fsh/profiles/*.fsh` for profiler og invariants
-3. `LMDI/input/fsh/extensions/*.fsh` for extensions
-4. `LMDI/input/fsh/valuesets/*.fsh` for valuesets og codesystems
-5. `LMDI/input/fsh/namingsystems/*.fsh` for naming systems
-6. `LMDI/input/fsh/examples/*.fsh` for eksempler og scenarier
+1. `references/sushi-config.yaml` for gjeldende versjon, canonical, dato og dependencies
+2. `references/fsh/aliases.fsh` for globale aliases brukt på tvers av profiler
+3. `references/fsh/profiles/*.fsh` for profiler, invariants og inline eksempler
+4. `references/fsh/extensions/*.fsh` for extensions
+5. `references/fsh/valuesets/*.fsh` for valuesets og codesystems
+6. `references/fsh/namingsystems/*.fsh` for naming systems
 
-Behandle FSH som normativ kilde. `README.md`, `CLAUDE.md` og eldre user-skills kan være utdaterte.
+Behandle FSH som normativ kilde. Denne skillen gir oversikt og kontekst, men **les alltid relevant FSH-fil for detaljer om kardinaliteter, constraints, bindings og slicing**. Hvis skillen og FSH motsier hverandre, stol på FSH.
+
+**Snapshot-modell:** `references/`-mappen er en generert snapshot — kun for lesing og oppslag. Oppdatering av snapshoten skjer i kilderepoet via `scripts/sync_references.sh` (vedlikeholdsmodus, ikke del av normal bruk). Distribuert som ZIP brukes skillen utelukkende til lesing.
 
 ## Gjeldende IG-metadata
 
@@ -34,7 +36,7 @@ Behandle FSH som normativ kilde. `README.md`, `CLAUDE.md` og eldre user-skills k
   - `hl7.fhir.uv.extensions.r4` `5.2.0`
   - `hl7.fhir.no.basis` `2.2.0`
 
-## Aliases fra repoet
+## Aliases
 
 - `NoBasisPatient` = `http://hl7.no/fhir/StructureDefinition/no-basis-Patient`
 - `NoBasisAddress` = `http://hl7.no/fhir/StructureDefinition/no-basis-Address`
@@ -44,6 +46,7 @@ Behandle FSH som normativ kilde. `README.md`, `CLAUDE.md` og eldre user-skills k
 - `$kommunenummer-alle` = `urn:oid:2.16.578.1.12.4.1.1.3402`
 - `$organization-type` = `http://terminology.hl7.org/CodeSystem/organization-type`
 - `$ATC` = `http://www.whocc.no/atc`
+- `$organisatoriskBetegnelse` = `urn:oid:2.16.578.1.12.4.1.1.8624`
 - `$LMDISubstance` = `http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-substance`
 - `$LMDIMedication` = `http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-medication`
 
@@ -84,7 +87,7 @@ Merk: `NoBasisPractitioner` brukes som parent i `lmdi-Practitioner.fsh`, men er 
 - `LokalLegemiddelkatalogCodeSystem`
 - `KommunenummerCodeSystem`
 
-### NamingSystems definert i repoet
+### NamingSystems
 
 - `http://fh.no/fhir/NamingSystem/lokaltVirkemiddel`
 - `http://dmp.no/fhir/NamingSystem/festLegemiddelDose`
@@ -92,200 +95,42 @@ Merk: `NoBasisPractitioner` brukes som parent i `lmdi-Practitioner.fsh`, men er 
 - `http://dmp.no/fhir/NamingSystem/festLegemiddelPakning`
 - `http://dmp.no/fhir/NamingSystem/festLegemiddelVirkestoff`
 
-Merk: `lmrLopenummer` og `fest-varenummer` brukes i profilen og i `LegemiddelKoder`, men har ikke egne NamingSystem-instansfiler i repoet.
+Merk: `lmrLopenummer` og `fest-varenummer` brukes i profilen og i `LegemiddelKoder`, men har ikke egne NamingSystem-instansfiler.
 
-## Viktigste profilregler
+## Profilregler, extensions og valuesets — mappingtabell
 
-### Legemiddeladministrering
+Detaljerte profilregler (kardinaliteter, constraints, bindings, slicing) finnes i FSH-filene. Bruk tabellen under for å finne riktig fil. Alle stier er relative til skill-mappen.
 
-- `status` er bundet til `LegemiddeladministreringStatus` (kun `completed` | `entered-in-error`)
-- `subject` refererer kun til `Pasient`
-- `medication[x]` refererer kun til `Legemiddel`
-- `effective[x]` er `1..1` og bare `dateTime` eller `Period`
-- invariant `time-required` gjelder for `effectiveDateTime`, `effectivePeriod.start` og `effectivePeriod.end`
-- `context` er MS og refererer til `Episode`
-- `request` er MS og refererer til `Legemiddelrekvirering`
-- `reasonReference` refererer til `Diagnose`
-- `dosage.route.coding` er `1..*` og lukket slicing på `system` med slices `SCT` og `OID7477`
-- `dosage.dose` er `1..1`
-- `dosage.rateRatio` er MS
-- disse elementene er slått av: `device`, `note`, `partOf`, `performer`, `supportingInformation`, `text`, `eventHistory`, `dosage.text`, `dosage.route.text`
+| Artefakt | FSH-fil | Relevante extensions | Relevante valuesets |
+|---|---|---|---|
+| lmdi-medicationadministration | `references/fsh/profiles/lmdi-MedicationAdministration.fsh` | — | `LegemiddeladministreringStatus` (definert i samme fil) |
+| lmdi-medication | `references/fsh/profiles/lmdi-Medication.fsh` | `references/fsh/extensions/lmdi-LegemiddelClassification.fsh` | `references/fsh/valuesets/lmdi-LegemiddelKoderValueSet.fsh`, `references/fsh/valuesets/lmdi-LokalLegemiddelKatalogValues.fsh` |
+| lmdi-patient | `references/fsh/profiles/lmdi-Patient.fsh` | — | `references/fsh/valuesets/lmdi-address-valuesets.fsh`, `references/fsh/valuesets/lmdi-kommunenummer-alle.fsh` |
+| lmdi-encounter | `references/fsh/profiles/lmdi-Encounter.fsh` | `references/fsh/extensions/lmdi-ext-npr-episode-identifier.fsh` | — |
+| lmdi-condition | `references/fsh/profiles/lmdi-Condition.fsh` | — | — |
+| lmdi-organization | `references/fsh/profiles/lmdi-Organization.fsh` | — | `references/fsh/valuesets/lmdi-address-valuesets.fsh`, `references/fsh/valuesets/lmdi-kommunenummer-alle.fsh` |
+| lmdi-practitioner | `references/fsh/profiles/lmdi-Practitioner.fsh` | — | — |
+| lmdi-substance | `references/fsh/profiles/lmdi-Substance.fsh` | — | — |
+| lmdi-medicationrequest | `references/fsh/profiles/lmdi-MedicationRequest.fsh` | `references/fsh/extensions/lmdi-ext-del-av-behandlingsregime.fsh`, `references/fsh/extensions/lmdi-ext-klinisk-studie.fsh`, `references/fsh/extensions/lmdi-ext-prosentvis-doseendring.fsh` | — |
+| lmdi-bundle | `references/fsh/profiles/LegemiddelregisterBundle.fsh` | — | — |
+| legemiddel-classification (ext) | `references/fsh/extensions/lmdi-LegemiddelClassification.fsh` | — | `references/fsh/valuesets/lmdi-ATCValueSet.fsh` |
+| npr-episode-identifier (ext) | `references/fsh/extensions/lmdi-ext-npr-episode-identifier.fsh` | — | — |
+| lmdi-del-av-behandlingsregime (ext) | `references/fsh/extensions/lmdi-ext-del-av-behandlingsregime.fsh` | — | — |
+| lmdi-klinisk-studie (ext) | `references/fsh/extensions/lmdi-ext-klinisk-studie.fsh` | — | — |
+| lmdi-prosentvis-doseendring (ext) | `references/fsh/extensions/lmdi-ext-prosentvis-doseendring.fsh` | — | — |
+| LegemiddeladministreringStatus (vs) | `references/fsh/profiles/lmdi-MedicationAdministration.fsh` | — | — |
+| LegemiddelKoder (vs) | `references/fsh/valuesets/lmdi-LegemiddelKoderValueSet.fsh` | — | — |
+| ATCValueSet (vs) | `references/fsh/valuesets/lmdi-ATCValueSet.fsh` | — | — |
+| LmdiAddressUse (vs) | `references/fsh/valuesets/lmdi-address-valuesets.fsh` | — | — |
+| LmdiAddressType (vs) | `references/fsh/valuesets/lmdi-address-valuesets.fsh` | — | — |
+| KommunenummerValueSet (vs) | `references/fsh/valuesets/lmdi-kommunenummer-alle.fsh` | — | — |
+| LokalLegemiddelkatalogValues (vs) | `references/fsh/valuesets/lmdi-LokalLegemiddelKatalogValues.fsh` | — | — |
 
-### Legemiddel
-
-- invariant `lmdi-medication-code-or-ingredient`: `code.coding.exists() or ingredient.exists()`
-- `code` er extensible bundet til `LegemiddelKoder`
-- `code.coding` har åpen slicing på `system`
-- støttede `code.coding`-slicer:
-  - `FestLegemiddeldose`
-  - `FestLmrLopenr`
-  - `FestLegemiddelMerkevare`
-  - `FestLegemiddelpakning`
-  - `Varenummer`
-  - `FestVirkestoff`
-  - `LokaltLegemiddel`
-  - `SCT`
-- `LokaltLegemiddel.display` er `1..1`
-- `extension` har lukket slicing (`#closed`); kun `extension[classification]` (`0..1`, `LegemiddelClassification`) er tillatt
-- `code.text` er `0..0`
-- `form.text` er `0..0`
-- `form.coding` er lukket slicing med `OID7448` og `SCT`; `form.coding.system` og `form.coding.code` er `1..1`, `form.coding.display` er MS
-- `batch` er MS
-- `ingredient.item[x]` er bare `Reference` eller `CodeableConcept`
-- `ingredient.itemReference` kan bare peke til `lmdi-substance` eller `lmdi-medication`
-- `ingredient.itemCodeableConcept` har preferred binding til `LegemiddelKoder`
-- `manufacturer` og `text` er slått av
-
-### Pasient
-
-- basert på `no-basis-Patient`
-- `address` er MS og kun `NoBasisAddress`
-- `address.type` er fast `physical` og bundet til `LmdiAddressType`
-- `address.use` er required bundet til `LmdiAddressUse` (`home`, `temp`, `old`)
-- `address.district.extension[municipalitycode]` bruker kodeverk `3402`
-- `address.extension[urbanDistrict]` bruker kodeverk `3403`
-- `address.extension[official]`, `address.extension[propertyInformation]` og `address.country` er `0..0`
-- `birthDate` og `gender` er MS
-- `identifier[FNR]` og `identifier[DNR]` er støttet (begge har `value 1..1`); `identifier[FHN]` og `identifier[HNR]` er slått av
-- `citizenship`, `name`, `telecom`, `managingOrganization`, `maritalStatus`, `photo`, `deceased[x]`, `multipleBirth[x]`, `active`, `communication`, `contact`, `generalPractitioner`, `link` og `text` er slått av
-
-### Episode
-
-- `extension[nprEpisodeIdentifier]` er `0..1` og MS
-- `serviceProvider` refererer kun til `Organisasjon`
-- store deler av `Encounter` er slått av, blant annet `subject`, `type`, `period`, `reasonCode`, `reasonReference`, `diagnosis`, `location`, `partOf` og `text`
-
-### Diagnose
-
-- `subject` er `1..1` og refererer kun til `Pasient`
-- `code` er `1..1`
-- `code.coding` er lukket slicing på `system` med `SCT`, `ICD10`, `ICD11`, `ICPC2`
-- `stage.summary` er satt til `1..1`
-- `encounter`, `text`, `category`, `severity`, `bodySite`, `abatement[x]`, `onset[x]`, `recorder`, `recordedDate`, `asserter`, `evidence`, `note` og `stage.assessment` er slått av
-
-### Organisasjon
-
-- basert på `no-basis-Organization`
-- invariant `lmdi-org-identifier`: minst én identifier med system `ENH` eller `RSH`
-- `identifier` er MS, med slicene `ENH` og `RSH` fra no-basis
-- `name` er `1..1` og MS
-- `partOf` er MS og refererer kun til `Organisasjon`
-- `address` er MS
-- `address.type` er fast `physical` og bundet til `LmdiAddressType`
-- `address.district.extension[municipalitycode]` og `address.extension[urbanDistrict]` brukes
-- `text`, `active`, `telecom`, `contact`, `endpoint`, `address.text`, `address.line`, `address.city`, `address.postalCode`, `address.country` er slått av
-
-### Helsepersonell
-
-- basert på `no-basis-Practitioner`
-- `identifier` bruker lukket slicing, kun `identifier[HPR]` tillatt
-- `identifier[HPR]` er `0..1` og MS
-- `identifier[FNR]` og `identifier[DNR]` er slått av
-- `text`, `name`, `telecom`, `address`, `gender`, `birthDate`, `photo`, `qualification`, `communication`, `active` er slått av
-
-### Virkestoff
-
-- basert på `no-basis-Substance`
-- `category` er `1..1`
-- `text`, `description` og `ingredient` er slått av
-
-### Legemiddelrekvirering
-
-- `extension[prosentvisDoseendring]`, `extension[delAvBehandlingsregime]` og `extension[kliniskStudie]` støttes
-- `identifier`, `status`, `intent`, `medication[x]`, `subject` og `requester` er MS
-- `medication[x]` refererer kun til `Legemiddel`
-- `subject` refererer kun til `Pasient`
-- `requester` refererer kun til `Helsepersonell`
-- `reasonReference` refererer kun til `Diagnose`
-- `priorPrescription` refererer kun til `Legemiddelrekvirering`
-- `encounter` refererer kun til `Episode`
-- `reported[x]` er bare `boolean`
-- disse elementene er slått av: `text`, `recorder`, `insurance`, `supportingInformation`, `performer`, `performerType`, `basedOn`, `note`, `dispenseRequest`, `detectedIssue`, `eventHistory`, `dosageInstruction.text`, `dosageInstruction.patientInstruction`
-
-### LegemiddelregisterBundle
-
-- `identifier`, `timestamp`, `type`, `entry`, `entry.request`, `entry.request.method` og `entry.resource` er påkrevd/MS som definert i profilen
-- `type` er fast `transaction`
-- `entry.request.method` er fast `POST`
-- invariant `lr-allowed-resources` tillater bare disse profilene:
-  - `lmdi-condition`
-  - `lmdi-practitioner`
-  - `lmdi-encounter`
-  - `lmdi-medication`
-  - `lmdi-medicationadministration`
-  - `lmdi-medicationrequest`
-  - `lmdi-organization`
-  - `lmdi-patient`
-  - `lmdi-substance`
-- `total` og `link` er slått av
-
-## Extensions
-
-### LegemiddelClassification
-
-- URL: `http://hl7.no/fhir/ig/lmdi/StructureDefinition/legemiddel-classification`
-- Context: `Medication`
-- `value[x]` er kun `CodeableConcept`
-- `valueCodeableConcept` er `1..1` og MS
-- binding: preferred til `http://fhir.no/ValueSet/atc-valueset`
-
-### NprEpisodeIdentifier
-
-- URL: `http://hl7.no/fhir/ig/lmdi/StructureDefinition/npr-episode-identifier`
-- Context: `Encounter`
-- kompleks extension med:
-  - `stringIdentifier` `0..1` MS, `valueString 1..1`
-  - `uuidIdentifier` `0..1` MS, `valueUuid 1..1`
-- invariant `npr-episode-at-least-one`: minst én av subextensions må finnes
-
-### DelAvBehandlingsregime
-
-- URL: `http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-del-av-behandlingsregime`
-- Context: `MedicationRequest`
-- `value[x]` er kun `string`
-
-### KliniskStudie
-
-- URL: `http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-klinisk-studie`
-- Context: `MedicationRequest`
-- `value[x]` er kun `boolean`
-
-### ProsentvisDoseendring
-
-- URL: `http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-prosentvis-doseendring`
-- Context: `MedicationRequest`
-- `value[x]` er kun `Quantity`
-- `valueQuantity.system` = `http://unitsofmeasure.org`
-- `valueQuantity.code` = `%`
-- `valueQuantity.unit` = `%`
-
-## ValueSets og kodeverk
-
-- `LegemiddeladministreringStatus`
-  - URL: `http://hl7.no/fhir/ig/lmdi/ValueSet/lmdi-medicationadministrationstatus`
-  - koder fra `http://terminology.hl7.org/CodeSystem/medication-admin-status`
-  - tillatte koder: `completed`, `entered-in-error`
-- `LegemiddelKoder`
-  - URL: `http://hl7.no/fhir/ig/lmdi/ValueSet/legemiddel-koder`
-  - inkluderer `SNOMED CT`, `festLegemiddelMerkevare`, `festLegemiddelVirkestoff`, `festLegemiddelPakning`, `festLegemiddelDose`, `lmrLopenummer`, `fest-varenummer`, `lokaltVirkemiddel`
-- `ATCValueSet`
-  - URL: `http://fhir.no/ValueSet/atc-valueset`
-  - inkluderer `http://www.whocc.no/atc`
-- `LmdiAddressUse`
-  - URL: `http://hl7.no/fhir/ig/lmdi/ValueSet/lmdi-address-use`
-  - koder: `home`, `temp`, `old`
-- `LmdiAddressType`
-  - URL: `http://hl7.no/fhir/ig/lmdi/ValueSet/lmdi-address-type`
-  - kode: `physical`
-- `KommunenummerValueSet`
-  - URL: `http://hl7.no/fhir/ig/lmdi/ValueSet/kommunenummer-alle`
-  - system: `urn:oid:2.16.578.1.12.4.1.1.3402`
-- `LokalLegemiddelkatalogValues`
-  - URL: `http://hl7.no/fhir/ig/lmdi/ValueSet/LokalLegemiddelkatalogValues`
-  - system: `http://hl7.no/fhir/ig/lmdi/CodeSystem/LokalLegemiddelkatalogCodeSystem`
-  - koder:
-    - `metavisionkatalogFraHso`
-    - `metavisionkatalogFraHN`
+**Arbeidsinstruksjon:**
+- Les alltid relevant FSH-fil før du svarer på detaljspørsmål om en artefakt (profil, extension eller valueset)
+- FSH er normativ kilde — hvis skillen og FSH motsier hverandre, stol på FSH
+- Les extensions og valuesets som er referert fra profilen ved behov
+- Alle FSH-filer ligger under `references/fsh/`: `aliases.fsh` i rotmappen, og undermappene `profiles/`, `extensions/`, `valuesets/`, `namingsystems/`
 
 ## Viktige identifikatorer og systemer
 
@@ -317,19 +162,24 @@ Merk: `lmrLopenummer` og `fest-varenummer` brukes i profilen og i `LegemiddelKod
 - `Organisasjon.partOf -> Organisasjon`
 - `Diagnose.subject -> Pasient`
 
-## Eksempler som finnes i repoet
+## Eksempler
 
-- `lmdi-example-1.fsh`: inline/contained eksempel
-- `lmdi-example-2.fsh`: minimal contained referanse
-- `lmdi-example-3-logical.fsh`: identifier-baserte/logiske referanser
-- `lmdi-example-LokalLegemiddelKatalog.fsh`: lokalt legemiddel med ingredient
-- `lmdi-example-scenario-sykehjem.fsh`: Scenario A, sykehjem med organisasjonshierarki
-- `lmdi-example-scenario-rekvirering.fsh`: Scenario B, rekvirering + diagnose + administrering
-- `lmdi-example-scenario-kjemoterapi.fsh`: Scenario C, kjemoterapi med alle MedicationRequest-extensions
+Alle eksempler er definert inline i profilfilene (ingen separat `examples/`-mappe). Hver profil-FSH-fil inneholder `Instance:`-definisjoner etter profildefinisjonen:
+
+- **lmdi-MedicationAdministration.fsh**: `Administrering-Oral` (oral administrering), `Administrering-Infusjon` (infusjonsadministrering)
+- **lmdi-Medication.fsh**: `Legemiddel-Oksykodon-FEST-Virkestoff` (FEST virkestoff-kode), `Legemiddel-Paracetamol-FEST-Merkevare` (FEST merkevare-kode), `Legemiddel-Monoket-FEST-Pakning` (FEST pakningskode), `Legemiddel-Lokalt-Med-Flere-Ingredienser` (lokalt legemiddel med flere ingredienser)
+- **lmdi-Patient.fsh**: `Pasient-Uten-Personidentifikator` (uten FNR/DNR), `Pasient-Med-FNR` (med fødselsnummer), `Pasient-Med-DNR` (med D-nummer)
+- **lmdi-Encounter.fsh**: `Episode-Sykehus` (spesialisthelsetjenesten), `Episode-Sykehjem` (primærhelsetjenesten)
+- **lmdi-Condition.fsh**: `Diagnose-ICD10` (ICD-10-kode), `Diagnose-SNOMED-CT` (SNOMED CT og ICD-10)
+- **lmdi-Organization.fsh**: `Organisasjon-Kommune` (kommune), `Organisasjon-Sykehjem` (sykehjem), `Organisasjon-HF` (helseforetak), `Organisasjon-Sykehus` (sykehus), `Organisasjon-Sykehusavdeling` (spesialistavdeling)
+- **lmdi-MedicationRequest.fsh**: `Rekvirering-Paracetamol` (enkel rekvirering), `Rekvirering-Kjemoterapi` (kjemoterapi med doseendring, behandlingsregime og klinisk studie)
+- **lmdi-Practitioner.fsh**: `Helsepersonell-Med-HPR` (med HPR-nummer), `Helsepersonell-Uten-HPR` (uten HPR-nummer)
+- **lmdi-Substance.fsh**: `Virkestoff-Oksykodon` (eksempel på virkestoff)
+- **LegemiddelregisterBundle.fsh**: `Bundle-Scenario-Sykehjem-Oksykodon` (transaction-bundle med sykehjemsscenario)
 
 ## Svarstil
 
 - Skill mellom normative regler og eksempeldata
 - Skill mellom ting som er bundet/fiksert og ting som bare er anbefalt i `short`, `definition` eller `comment`
 - Ved tvil om en URL eller generated id som ikke er eksplisitt satt i FSH, verifiser mot genererte artefakter hvis de finnes
-- Hvis repoets dokumentasjon motsier FSH, stol på FSH
+- Hvis annen dokumentasjon motsier FSH, stol på FSH

--- a/.claude/skills/lmdi-fhir/references/fsh/aliases.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/aliases.fsh
@@ -1,0 +1,18 @@
+// No-basis aliases
+Alias: NoBasisPatient = http://hl7.no/fhir/StructureDefinition/no-basis-Patient
+Alias: NoBasisAddress = http://hl7.no/fhir/StructureDefinition/no-basis-Address
+Alias: NoBasisOrganization = http://hl7.no/fhir/StructureDefinition/no-basis-Organization
+Alias: NoBasisSubstance = http://hl7.no/fhir/StructureDefinition/no-basis-Substance
+Alias: $VsLmdiUrbanDistrict = urn:oid:2.16.578.1.12.4.1.1.3403
+Alias: $kommunenummer-alle = urn:oid:2.16.578.1.12.4.1.1.3402
+Alias: $organization-type = http://terminology.hl7.org/CodeSystem/organization-type
+
+// ATC alias
+Alias: $ATC = http://www.whocc.no/atc
+
+// Volven alias
+Alias: $organisatoriskBetegnelse = urn:oid:2.16.578.1.12.4.1.1.8624
+
+// LMDI Profile aliases
+Alias: $LMDISubstance = http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-substance
+Alias: $LMDIMedication = http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-medication

--- a/.claude/skills/lmdi-fhir/references/fsh/extensions/lmdi-LegemiddelClassification.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/extensions/lmdi-LegemiddelClassification.fsh
@@ -1,0 +1,18 @@
+Extension: LegemiddelClassification
+Id: legemiddel-classification
+Title: "Legemiddel Classification"
+Description: "Klassifisering av legemidler, primært med ATC-koder (Anatomisk Terapeutisk Kjemisk legemiddelregister)."
+* ^context.type = #element
+* ^context.expression = "Medication"
+* ^status = #active
+* ^date = "2025-09-12"
+* ^publisher = "Folkehelseinstituttet"
+* ^contact.name = "Folkehelseinstituttet"
+* ^contact.telecom.system = #url
+* ^contact.telecom.value = "https://www.fhi.no"
+
+* value[x] only CodeableConcept
+* valueCodeableConcept 1..1 MS
+* valueCodeableConcept ^binding.strength = #preferred
+* valueCodeableConcept ^binding.description = "ATC kode fra WHO ATC kodesystem"
+* valueCodeableConcept ^binding.valueSet = "http://fhir.no/ValueSet/atc-valueset"

--- a/.claude/skills/lmdi-fhir/references/fsh/extensions/lmdi-ext-del-av-behandlingsregime.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/extensions/lmdi-ext-del-av-behandlingsregime.fsh
@@ -1,0 +1,7 @@
+Extension: DelAvBehandlingsregime
+Id: lmdi-del-av-behandlingsregime
+Title: "Del av behandlingsregime"
+Description: "Navnet på kuren, behandlingsregimet eller protokollen legemidlet gis som en del av. Spesielt relevant ved kjemoterapi."
+* ^context.type = #element
+* ^context.expression = "MedicationRequest"
+* value[x] only string

--- a/.claude/skills/lmdi-fhir/references/fsh/extensions/lmdi-ext-klinisk-studie.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/extensions/lmdi-ext-klinisk-studie.fsh
@@ -1,0 +1,7 @@
+Extension: KliniskStudie
+Id: lmdi-klinisk-studie
+Title: "Klinisk studie"
+Description: "Angir om legemidlet gis som en del av en klinisk studie."
+* ^context.type = #element
+* ^context.expression = "MedicationRequest"
+* value[x] only boolean

--- a/.claude/skills/lmdi-fhir/references/fsh/extensions/lmdi-ext-npr-episode-identifier.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/extensions/lmdi-ext-npr-episode-identifier.fsh
@@ -1,0 +1,28 @@
+Extension: NprEpisodeIdentifier
+Id: npr-episode-identifier
+Title: "NPR Episode Identifier"
+Description: "Entydig identifikator for episode som skal sendes til LMDI. Extensionen kan bære både string-basert og UUID-basert representasjon av den valgte NPR-identifikatoren. Forretningsregelen for LMDI er at kun én NPR-identifikator skal sendes per episode. Selv om helseinstitusjonens systemer kan ha flere NPR-identifiere for samme episode lokalt, skal kun én velges ved innsending - gjerne den første eller foretrukne identifikatoren lokalt."
+* ^context.type = #element
+* ^context.expression = "Encounter"
+* ^status = #active
+
+* extension contains
+    stringIdentifier 0..1 MS and
+    uuidIdentifier 0..1 MS
+
+* extension[stringIdentifier] ^short = "String-representasjon av NPR episodeidentifikatoren"
+* extension[stringIdentifier] ^definition = "String-representasjon av den valgte NPR episodeidentifikatoren som sendes til LMDI. Skal oppgis dersom stringrepresentasjonen av identifikatoren er tilgjengelig."
+* extension[stringIdentifier].value[x] only string
+* extension[stringIdentifier].valueString 1..1
+
+* extension[uuidIdentifier] ^short = "UUID-representasjon av NPR episodeidentifikatoren"
+* extension[uuidIdentifier] ^definition = "UUID-representasjon av den valgte NPR episodeidentifikatoren som sendes til LMDI. Skal oppgis dersom UUID-representasjonen av identifikatoren er tilgjengelig."
+* extension[uuidIdentifier].value[x] only uuid
+* extension[uuidIdentifier].valueUuid 1..1
+
+* obeys npr-episode-at-least-one
+
+Invariant: npr-episode-at-least-one
+Description: "Minst én NPR episode identifikator (string eller UUID) må oppgis"
+Expression: "extension('stringIdentifier').exists() or extension('uuidIdentifier').exists()"
+Severity: #error

--- a/.claude/skills/lmdi-fhir/references/fsh/extensions/lmdi-ext-prosentvis-doseendring.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/extensions/lmdi-ext-prosentvis-doseendring.fsh
@@ -1,0 +1,10 @@
+Extension: ProsentvisDoseendring
+Id: lmdi-prosentvis-doseendring
+Title: "Prosentvis doseendring"
+Description: "Doseendring i prosent, sammenlignet med opprinnelig dosering. Spesielt relevant ved kjemoterapi."
+* ^context.type = #element
+* ^context.expression = "MedicationRequest"
+* value[x] only Quantity
+* valueQuantity.system = "http://unitsofmeasure.org"
+* valueQuantity.code = #%
+* valueQuantity.unit = "%"

--- a/.claude/skills/lmdi-fhir/references/fsh/namingsystems/lmdi-lokaltVirkemiddel.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/namingsystems/lmdi-lokaltVirkemiddel.fsh
@@ -1,0 +1,16 @@
+// LokaltLegemiddel: benyttes ved angivelse av legemiddel fra lokal legemiddelkatalog
+Instance: lmdi-lokaltLegemiddel
+InstanceOf: NamingSystem
+Usage: #definition
+* name = "lmdiLokaltLegemiddel"
+* status = #draft
+* kind = #identifier
+* date = "2024-06-10"
+// Publisher blir overkjørt og blir korrigert til FHI. Blir rettet når instansene flyttes til no-basis-IG. 
+* publisher = "Folkehelseinstituttet"
+* responsible = "Folkehelseinstituttet"
+* description = "Id for angivelse av legemiddel fra lokal legemiddelkatalog"
+* jurisdiction = urn:iso:std:iso:3166#NO "Norway"
+* uniqueId[0].type = #uri
+* uniqueId[=].value = "http://fh.no/fhir/NamingSystem/lokaltVirkemiddel"
+* uniqueId[=].preferred = true

--- a/.claude/skills/lmdi-fhir/references/fsh/namingsystems/no-basis-fest-legemiddeldose.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/namingsystems/no-basis-fest-legemiddeldose.fsh
@@ -1,0 +1,18 @@
+// Under utvikling i LMDI-prosjektet. 
+// LegemiddelDose: Rekvirering av en bestemt merkevare med ID (LMR-nummer) som representerer minste plukkbare enhet, f.eks. 1 ampulle eller 1 tablett.
+// Mål: Være en del av no-basis. 
+Instance: no-basis-fest-legemiddeldose
+InstanceOf: NamingSystem
+Usage: #definition
+* name = "festLegemiddelDose"
+* status = #draft
+* kind = #identifier
+* date = "2024-06-10"
+// Publisher blir overkjørt og blir korrigert til FHI. Blir rettet når instansene flyttes til no-basis-IG. 
+* publisher = "Helsedirektoratet"
+* responsible = "Direktoratet for medisinske produkter"
+* description = "FEST-id for dose. Rekvirering av en bestemt merkevare med ID (LMR-nummer) som representerer minste plukkbare enhet, f.eks. 1 ampulle eller 1 tablett."
+* jurisdiction = urn:iso:std:iso:3166#NO "Norway"
+* uniqueId[0].type = #uri
+* uniqueId[=].value = "http://dmp.no/fhir/NamingSystem/festLegemiddelDose"
+* uniqueId[=].preferred = true

--- a/.claude/skills/lmdi-fhir/references/fsh/namingsystems/no-basis-fest-legemiddelmerkevare.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/namingsystems/no-basis-fest-legemiddelmerkevare.fsh
@@ -1,0 +1,18 @@
+// Under utvikling i LMDI-prosjektet. 
+// LegemiddelMerkevare: Rekvirering av en styrke og form av en bestemt merkevare. Pr. 2024 er det ikke lenger ønskelig at det rekvireres på LegemiddelMerkevare
+// Mål: Være en del av no-basis. 
+Instance: no-basis-fest-legemiddelmerkevare
+InstanceOf: NamingSystem
+Usage: #definition
+* name = "festLegemiddelMerkevare"
+* status = #draft
+* kind = #identifier
+* date = "2024-06-10"
+// Publisher blir overkjørt og blir korrigert til FHI. Blir rettet når instansene flyttes til no-basis-IG. 
+* publisher = "Helsedirektoratet"
+* responsible = "Direktoratet for medisinske produkter"
+* description = "FEST-id for legemiddel merkevare. Rekvirering av en styrke og form av en bestemt merkevare. Pr. 2024 er det ikke lenger ønskelig at det rekvireres på LegemiddelMerkevare."
+* jurisdiction = urn:iso:std:iso:3166#NO "Norway"
+* uniqueId[0].type = #uri
+* uniqueId[=].value = "http://dmp.no/fhir/NamingSystem/festLegemiddelMerkevare"
+* uniqueId[=].preferred = true

--- a/.claude/skills/lmdi-fhir/references/fsh/namingsystems/no-basis-fest-legemiddelpakning.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/namingsystems/no-basis-fest-legemiddelpakning.fsh
@@ -1,0 +1,20 @@
+// Under utvikling i LMDI-prosjektet.
+// LegemiddelPakningMerkevare: rekvirering av en bestemt pakning av en merkevare (varenummer)
+// Mål: Være en del av no-basis. 
+Instance: no-basis-fest-legemiddelpakning
+InstanceOf: NamingSystem
+Usage: #definition
+* name = "festLegemiddelPakning"
+* status = #draft
+* kind = #identifier
+* date = "2024-06-10"
+// Publisher blir overkjørt og blir korrigert til FHI. Blir rettet når instansene flyttes til no-basis-IG. 
+* publisher = "Helsedirektoratet"
+* responsible = "Direktoratet for medisinske produkter"
+* description = "FEST-id for legemiddelpakninger. Rekvirering av en bestemt pakning av en merkevare (varenummer)"
+* jurisdiction = urn:iso:std:iso:3166#NO "Norway"
+* uniqueId[0].type = #uri
+// Best om DMP/FEST/SAFEST har unike id/namespace som kan benyttes. 
+// Volven har ikke noe, da FEST-id egentlig ikke er kodeverk, men katalog(database)-nøkler.
+* uniqueId[=].value = "http://dmp.no/fhir/NamingSystem/festLegemiddelPakning"
+* uniqueId[=].preferred = true

--- a/.claude/skills/lmdi-fhir/references/fsh/namingsystems/no-basis-fest-legemiddelvirkestoff.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/namingsystems/no-basis-fest-legemiddelvirkestoff.fsh
@@ -1,0 +1,18 @@
+// Under utvikling i LMDI-prosjektet. 
+// LegemiddelVirkestoff: benyttes ved virkestoffrekvirering
+// Mål: Være en del av no-basis. 
+Instance: no-basis-fest-legemiddelvirkestoff
+InstanceOf: NamingSystem
+Usage: #definition
+* name = "festLegemiddelVirkestoff"
+* status = #draft
+* kind = #identifier
+* date = "2024-06-10"
+// Publisher blir overkjørt og blir korrigert til FHI. Blir rettet når instansene flyttes til no-basis-IG. 
+* publisher = "Helsedirektoratet"
+* responsible = "Direktoratet for medisinske produkter"
+* description = "FEST-id for virkestoff. Benyttes ved virkestoffrekvirering"
+* jurisdiction = urn:iso:std:iso:3166#NO "Norway"
+* uniqueId[0].type = #uri
+* uniqueId[=].value = "http://dmp.no/fhir/NamingSystem/festLegemiddelVirkestoff"
+* uniqueId[=].preferred = true

--- a/.claude/skills/lmdi-fhir/references/fsh/profiles/LegemiddelregisterBundle.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/profiles/LegemiddelregisterBundle.fsh
@@ -1,0 +1,93 @@
+Profile: LegemiddelregisterBundle
+Parent: Bundle
+Id: lmdi-bundle
+Title: "LegemiddelregisterBundle"
+Description: "Profil av Bundle for Legemiddelregisteret. Støtter bare transaction-type og POST-operasjoner, med begrensninger på tillatte ressurstyper."
+
+// Påkrevde felter
+* identifier 1..1 MS
+* timestamp 1..1 MS
+* type 1..1 MS
+* type = #transaction (exactly)
+* type ^short = "Må være av type transaction"
+* type ^definition = "Angir at bundle må være av type transaction"
+
+// Deaktiverte elementer
+* total 0..0
+* link 0..0
+
+// Entry-elementer
+* entry 1..* MS
+* entry ^short = "Innholdselementer i bundle"
+* entry ^definition = "Inneholder ressursene som skal sendes inn til registeret"
+
+* entry.request 1..1 MS
+* entry.request.method 1..1 MS
+* entry.request.method = #POST (exactly)
+* entry.request.method ^short = "Må være POST"
+* entry.request.method ^definition = "Angir at alle forespørsler i bundle må være av type POST"
+
+* entry.request.url 1..1
+* entry.request.url ^short = "URL for requesten (påkrevd, men verdien har ingen betydning)"
+* entry.request.url ^definition = "Representerer adressen for requesten. URL er påkrevd av FHIR-spesifikasjonen for transaction bundles, men selve verdien har ingen funksjonell betydning i dette tilfellet."
+
+* entry.resource 1..1 MS
+
+// Invariant for tillatte ressurstyper
+* obeys lr-allowed-resources
+
+Invariant: lr-allowed-resources
+Description: "Bundle kan bare inneholde følgende profilerte ressurstyper: Diagnose, Helsepersonell, Episode, Legemiddel, LegemiddelAdministrasjon, Legemiddelrekvirering, Organisasjon, Pasient, Virkestoff"
+Severity: #error
+Expression: "entry.all(
+  resource.meta.profile.where($this = 'http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-condition').exists() or
+  resource.meta.profile.where($this = 'http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-practitioner').exists() or
+  resource.meta.profile.where($this = 'http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-encounter').exists() or
+  resource.meta.profile.where($this = 'http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-medication').exists() or
+  resource.meta.profile.where($this = 'http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-medicationadministration').exists() or
+  resource.meta.profile.where($this = 'http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-medicationrequest').exists() or
+  resource.meta.profile.where($this = 'http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-organization').exists() or
+  resource.meta.profile.where($this = 'http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-patient').exists() or
+  resource.meta.profile.where($this = 'http://hl7.no/fhir/ig/lmdi/StructureDefinition/lmdi-substance').exists()
+)"
+
+// EKSEMPEL
+Instance: Bundle-Scenario-Sykehjem-Oksykodon
+InstanceOf: LegemiddelregisterBundle
+Usage: #example
+Title: "Oksykodonadministrering i sykehjem med separate ressurser"
+Description: "Eksempel på transaction-bundle satt sammen av gjenværende profildefinerte eksempelressurser."
+
+* identifier.system = "urn:oid:2.16.578.1.34.10.3"
+* identifier.value = "bundle-001"
+* timestamp = "2024-02-07T13:28:17.239+02:00"
+* type = #transaction
+
+// Ressurser i bundle
+* entry[0].resource = Pasient-Med-FNR
+* entry[0].request.method = #POST
+* entry[0].request.url = "Patient"
+
+* entry[1].resource = Helsepersonell-Med-HPR
+* entry[1].request.method = #POST
+* entry[1].request.url = "Practitioner"
+
+* entry[2].resource = Organisasjon-Sykehjem
+* entry[2].request.method = #POST
+* entry[2].request.url = "Organization"
+
+* entry[3].resource = Episode-Sykehus
+* entry[3].request.method = #POST
+* entry[3].request.url = "Encounter"
+
+* entry[4].resource = Legemiddel-Oksykodon-FEST-Virkestoff
+* entry[4].request.method = #POST
+* entry[4].request.url = "Medication"
+
+* entry[5].resource = Rekvirering-Kjemoterapi
+* entry[5].request.method = #POST
+* entry[5].request.url = "MedicationRequest"
+
+* entry[6].resource = Administrering-Oral
+* entry[6].request.method = #POST
+* entry[6].request.url = "MedicationAdministration"

--- a/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-Condition.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-Condition.fsh
@@ -1,0 +1,102 @@
+Profile: Diagnose
+Parent: Condition
+Id: lmdi-condition
+Title: "Diagnose"
+Description: "Diagnosen som pasienten har fått rekvirert eller administrert legemiddelet for."
+
+// Metadata
+* ^status = #draft
+* ^date = "2025-09-12"
+* ^publisher = "Folkehelseinstituttet"
+
+// Deaktiverte elementer
+* encounter 0..0
+* text 0..0
+* category 0..0
+* severity 0..0
+* bodySite 0..0
+* abatement[x] 0..0
+* onset[x] 0..0
+* recorder 0..0
+* recordedDate 0..0
+* asserter 0..0
+* evidence 0..0
+* note 0..0
+* stage.summary 1..1
+* stage.assessment 0..0
+
+// Grunnleggende elementer
+* subject 1..1
+* subject only Reference(Pasient)
+* subject ^short = "Pasienten diagnosen er knyttet til."
+
+// Diagnosekoding - hovedregler
+* code 1..1
+* code ^short = "Diagnosekode."
+* code ^definition = "Diagnosekode. Det er mulig å bruke ICD-10, ICD-11, ICPC-2 og SNOMED CT."
+
+* code.coding ^slicing.discriminator.type = #pattern
+* code.coding ^slicing.discriminator.path = "system"
+* code.coding ^slicing.rules = #closed
+
+// Diagnosekoding - kodesystemer
+* code.coding contains
+    SCT 0..1 and
+    ICD10 0..1 and 
+    ICD11 0..1 and 
+    ICPC2 0..1
+
+// SNOMED CT
+* code.coding[SCT] ^short = "SNOMED CT"
+* code.coding[SCT] ^definition = "SNOMED CT er ei systematisk samling av helsefaglege omgrep som kan brukast til å dokumentere og dele opplysningar knytt til pasientbehandlinga. Ved å bruke eit felles omgrepsapparat skal det bli lettare å kommunisere mellom ulike delar av helsetenesta."
+* code.coding[SCT].system = "http://snomed.info/sct"
+* code.coding[SCT].code 1..1
+
+// ICD-10
+* code.coding[ICD10] ^short = "ICD-10"
+* code.coding[ICD10] ^definition = "ICD-10: Den internasjonale statistiske klassifikasjonen av sykdommer og beslektede helseproblemer."
+* code.coding[ICD10].system = "urn:oid:2.16.578.1.12.4.1.1.7110"
+* code.coding[ICD10].code 1..1
+* code.coding[ICD10].code ^short = "Diagnosekode fra kodeverket"
+* code.coding[ICD10].display ^short = "Beskrivelse av diagnosekode (fra kodeverket)"
+
+// ICD-11
+* code.coding[ICD11] ^short = "ICD-11"
+* code.coding[ICD11] ^definition = "International Classification of Diseases, 11th Revision Mortality and Morbidity Statistics (MMS)."
+* code.coding[ICD11] ^comment = "Skal erstattes av navnerom som peker på generell ICD-11, ikke MMS."
+* code.coding[ICD11].system = "http://id.who.int/icd/release/11/mms"
+* code.coding[ICD11].system ^comment = "Kilde for URI: https://build.fhir.org/ig/HL7/UTG/CodeSystem-ICD11MMS.html"
+* code.coding[ICD11].code 1..1
+* code.coding[ICD11].code ^short = "Diagnosekode fra kodeverket"
+* code.coding[ICD11].display ^short = "Beskrivelse av diagnosekode (fra kodeverket)"
+
+// ICPC-2
+* code.coding[ICPC2] ^short = "ICPC-2"
+* code.coding[ICPC2] ^definition = "ICPC-2 er den internasjonale klassifikasjonen for helseproblemer, diagnoser og andre årsaker til kontakt med primærhelsetjenesten."
+* code.coding[ICPC2].system = "urn:oid:2.16.578.1.12.4.1.1.7170"
+* code.coding[ICPC2].code 1..1
+* code.coding[ICPC2].code ^short = "Diagnosekode fra kodeverket"
+* code.coding[ICPC2].display ^short = "Beskrivelse av diagnosekode (fra kodeverket)"
+
+// EKSEMPLER
+Instance: Diagnose-ICD10
+InstanceOf: Diagnose
+Description: "Eksempel på diagnose ICD-10"
+* subject = Reference(Pasient-Med-FNR)
+* stage.summary.text = "Indikasjonsdiagnose for legemiddelbehandling"
+* code.coding[ICD10].system = "urn:oid:2.16.578.1.12.4.1.1.7110"
+* code.coding[ICD10] = #R63.3
+* code.coding[ICD10].display = "Vanskeligheter med inntak og tilførsel av mat"
+
+Instance: Diagnose-SNOMED-CT
+InstanceOf: Diagnose
+Description: "Eksempel på diagnose SNOMED CT og ICD-10"
+* subject = Reference(Pasient-Med-FNR)
+* stage.summary.text = "Indikasjonsdiagnose for legemiddelbehandling"
+* code.coding[SCT].system = "http://snomed.info/sct"
+* code.coding[SCT] = #276241001
+* code.coding[SCT].display = "frykt for høyder"
+* code.coding[ICD10].system = "urn:oid:2.16.578.1.12.4.1.1.7110"
+* code.coding[ICD10] = #F40.2
+* code.coding[ICD10].display = "Spesifikke (isolerte) fobier"
+* code.text = "Høydeskrekk"

--- a/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-Encounter.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-Encounter.fsh
@@ -1,0 +1,51 @@
+Profile: Episode
+Parent: Encounter
+Id: lmdi-encounter
+Title: "Episode"
+Description: "Profil for en behandlingsepisode basert på Encounter-ressursen i FHIR. Denne profilen representerer et klinisk møte eller en behandling i helsevesenet, med fokus på organisatorisk tilhørighet."
+
+* extension contains NprEpisodeIdentifier named nprEpisodeIdentifier 0..1 MS
+* extension[nprEpisodeIdentifier] ^short = "NPR episodeidentifikator som sendes til LMDI"
+* extension[nprEpisodeIdentifier] ^definition = "Unik identifikator for episoden som skal sendes til LMDI. Selv om avsender kan ha flere NPR-identifiere for samme episode lokalt, skal kun én NPR-identifikator angis ved innsending til LMDI. Dersom flere identifiere finnes, velges gjerne den første eller foretrukne identifikatoren lokalt. Den valgte identifikatoren skal oppgis med sin string-representasjon og/eller UUID-representasjon dersom begge er tilgjengelig."
+
+* statusHistory 0..0 
+* classHistory 0..0
+* type 0..0
+* serviceType 0..0
+* priority 0..0
+* subject 0..0
+* episodeOfCare 0..0
+* basedOn 0..0
+* participant 0..0
+* appointment 0..0
+* period 0..0
+* length 0..0
+* reasonCode 0..0
+* reasonReference 0..0
+* diagnosis 0..0
+* account 0..0
+* hospitalization 0..0
+* location 0..0
+* partOf 0..0
+* text 0..0
+
+* serviceProvider only Reference(Organisasjon)
+* serviceProvider ^short = "Sted for episoden"
+
+// EKSEMPLER
+Instance: Episode-Sykehus
+InstanceOf: Episode
+Description: "Eksempel på episode i spesialisthelsetjenesten"
+* status = #finished
+* class = http://terminology.hl7.org/CodeSystem/v3-ActCode#IMP "inpatient encounter"
+* serviceProvider = Reference(Organisasjon-Sykehusavdeling)
+* identifier.value = "550e8400-e29b-41d4-a716-446655440000"
+* extension[nprEpisodeIdentifier].extension[stringIdentifier].valueString = "NPR987654321"
+* extension[nprEpisodeIdentifier].extension[uuidIdentifier].valueUuid = "urn:uuid:550e8400-e29b-41d4-a716-446655440000"
+
+Instance: Episode-Sykehjem
+InstanceOf: Episode
+Description: "Eksempel på episode på sykehjem"
+* status = #in-progress
+* class = http://terminology.hl7.org/CodeSystem/v3-ActCode#SS "short stay"
+* serviceProvider = Reference(Organisasjon-Sykehjem)

--- a/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-Medication.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-Medication.fsh
@@ -1,0 +1,211 @@
+Profile: Legemiddel
+Parent:   Medication
+Id:       lmdi-medication
+Title:    "Legemiddel"
+Description: "Beskrivelse av legemiddel."
+* ^status = #draft
+* ^date = "2025-09-30"
+* ^publisher = "Folkehelseinstituttet"
+
+* obeys lmdi-medication-code-or-ingredient
+* manufacturer 0..0
+* text 0..0
+
+* code.text 0..0
+* code from LegemiddelKoder (extensible)
+* code ^short = "Identifikator fra FEST, SNOMED CT eller LokalLegemiddelkatalog. Hvis ikke fylt ut, skal ingredient ha verdi. Hvis LokaltLegemiddel er fylt ut bør ingredient ha verdi."
+* code.coding ^slicing.discriminator.type = #value
+* code.coding ^slicing.discriminator.path = "system"
+* code.coding ^slicing.rules = #open
+* code.coding contains FestLegemiddeldose 0..1
+    and FestLmrLopenr 0..1
+    and FestLegemiddelMerkevare 0..1
+    and FestLegemiddelpakning 0..1
+    and Varenummer 0..1
+    and FestVirkestoff 0..1
+    and LokaltLegemiddel 0..1
+    and SCT 0..1
+
+* code.coding[FestLegemiddeldose].system = "http://dmp.no/fhir/NamingSystem/festLegemiddelDose"
+* code.coding[FestLmrLopenr].system = "http://dmp.no/fhir/NamingSystem/lmrLopenummer"
+* code.coding[FestLegemiddelMerkevare].system = "http://dmp.no/fhir/NamingSystem/festLegemiddelMerkevare"
+* code.coding[FestLegemiddelpakning].system = "http://dmp.no/fhir/NamingSystem/festLegemiddelPakning"
+* code.coding[Varenummer].system = "http://dmp.no/fhir/NamingSystem/fest-varenummer"
+* code.coding[FestVirkestoff].system = "http://dmp.no/fhir/NamingSystem/festLegemiddelVirkestoff"
+* code.coding[SCT].system = "http://snomed.info/sct"
+* code.coding[LokaltLegemiddel].system = "http://fh.no/fhir/NamingSystem/lokaltVirkemiddel"
+
+* code.coding[FestLegemiddeldose] ^short = "FEST-id for legemiddeldose"
+* code.coding[FestLmrLopenr] ^short = "Fest-løpenummer som identifiserer legemiddeldose"
+* code.coding[FestLegemiddelMerkevare] ^short = "FEST-id for LegemiddelMerkevare"
+* code.coding[FestLegemiddelpakning] ^short = "FEST-id for legemiddelpakning"
+* code.coding[Varenummer] ^short = "Varenummer - Unikt produktnummer for legemiddelpakninger"
+* code.coding[FestVirkestoff] ^short = "FEST-id for legemiddel virkestoff"
+* code.coding[LokaltLegemiddel] ^short = "Legemiddel fra lokal katalog"
+* code.coding[SCT] ^short = "SNOMED CT-kode for legemiddel"
+
+* code.coding[FestLegemiddeldose] ^definition = "Unik identifikator (legemiddeldose-id) for minste plukkbare enhet av en bestemt merkevare, f.eks. 1 tablett eller 1 ampulle."
+* code.coding[FestLmrLopenr]     ^definition = "LMR-nummer brukt til å identifisere en endose/minste enhet som kan utleveres; overtatt fra Sykehusapotekenes Legemiddelregister."
+* code.coding[FestLegemiddelMerkevare]     ^definition = "Unik identifikator for en bestemt styrke og legemiddelform av en merkevare (branded product) i FEST."
+* code.coding[FestLegemiddelpakning] ^definition = "Unik identifikator for en konkret pakning av en merkevare i katalogen LegemiddelPakningMerkevare."
+* code.coding[Varenummer]    ^definition = "Varenummeret for legemiddelpakningen; brukes som unikt produktnummer blant annet i resept- og apotekkjeden."
+* code.coding[FestVirkestoff]    ^definition = "Unik identifikator (LegemiddelVirkestoff_ID) for rekvirering på virkestoffnivå i FEST."
+* code.coding[LokaltLegemiddel]  ^definition = "Skal kun benyttes for legemidler fra lokal legemiddelkatalog/legemiddelregister. Hvis LokaltLegemiddel benyttes skal det avtales med FHI hvordan LMR skal få tilgang til legemiddelkatalogen for å hente informasjon om det lokale legemidlet. "
+* code.coding[SCT]               ^definition = "SNOMED CT-kode for legemiddel eller substans, for semantisk klassifisering og gruppering."
+
+* code.coding[FestLegemiddeldose].code ^short = "Identifikator fra FEST"
+* code.coding[FestLmrLopenr].code ^short = "7‑sifret nummer"
+* code.coding[FestLegemiddelMerkevare].code ^short = "Identifikator fra FEST"
+* code.coding[FestLegemiddelpakning].code ^short = "Identifikator fra FEST"
+* code.coding[Varenummer].code ^short = "Varenummer"
+* code.coding[FestVirkestoff].code ^short = "Identifikator fra FEST"
+* code.coding[LokaltLegemiddel].code ^short = "Identifikator fra lokal legemiddelkatalog/legemiddelregister"
+* code.coding[SCT].code ^short = "SNOMED CT-koden skal være et underbegrep av 'Legemiddel (product)' [763158003] eller 'Substans (substance)' [105590001]."
+
+* code.coding[FestLegemiddeldose].code 1..1
+* code.coding[FestLmrLopenr].code 1..1
+* code.coding[FestLegemiddelMerkevare].code 1..1
+* code.coding[FestLegemiddelpakning].code 1..1
+* code.coding[Varenummer].code 1..1
+* code.coding[FestVirkestoff].code 1..1
+* code.coding[LokaltLegemiddel].code 1..1
+* code.coding[SCT].code 1..1
+
+* code.coding[LokaltLegemiddel].display 1..1
+* code.coding[LokaltLegemiddel].display ^short = "Beskrivelse (f.eks. varenavn) for legemiddel fra lokal legemiddelkatalog/legemiddelregister"
+
+* extension ^slicing.discriminator.type = #value
+* extension ^slicing.discriminator.path = "url"
+* extension ^slicing.rules = #closed
+* extension contains LegemiddelClassification named classification 0..1
+* extension[classification] ^short = "Klassifisering av legemidlet ved bruk av ATC-kode fra WHO ATC kodesystem. Ett legemiddel kan ha inntil én ATC-kode."
+* extension[classification] ^definition = "Klassifisering av legemidlet ved bruk av ATC-kode fra WHO ATC kodesystem. Ett legemiddel kan ha inntil én ATC-kode."
+* extension[classification] ^comment = "Denne extension brukes for å angi legemidlets klassifisering i henhold til standardiserte kodesystemer, primært ATC-koder fra WHO."
+
+* form.text 0..0
+* form ^short = "Legemiddelform"
+* form.coding 1..*
+* form.coding.system 1..1
+* form.coding.code 1..1
+* form.coding.display MS
+* form.coding ^slicing.discriminator.type = #value
+* form.coding ^slicing.discriminator.path = "system"
+* form.coding ^slicing.rules = #closed
+* form.coding contains OID7448 0..1 and SCT 0..1
+* form.coding ^short = "Legemiddelform"
+* form.coding ^comment = "Kodet legemiddelform. Inntil videre begrenset til Legemiddelform (OID: 7448) og kodesetteksempel fra HL7 basert på SNOMED CT."
+* form.coding[OID7448] ^short = "Kodeverk Legemiddelform (OID:7448) fra FEST"
+* form.coding[SCT] ^short = "SNOMED CT Form Codes"
+* form.coding[OID7448].code 1..1
+* form.coding[OID7448].code ^short = "Verdi fra kodeverket"
+* form.coding[OID7448].display ^short = "Beskrivelse av koden (navn) fra kodeverket"
+* form.coding[OID7448].system = "urn:oid:2.16.578.1.12.4.1.1.7448" 
+* form.coding[SCT].system = "http://snomed.info/sct" 
+
+* batch MS
+* batch ^short = "Batch-nummer for legemiddelet"
+
+// Fix for targetProfile constraint error: Use type-specific constraints instead
+* ingredient ^short = "Virkestoff(er) som inngår i legemiddelet. Skal fylles ut hvis code ikke har verdi. Bør fylles ut hvis code.coding[LokaltLegemiddel] har verdi."
+* ingredient ^definition = "Virkestoff(er) som inngår i legemiddelet. Skal fylles ut hvis code ikke har verdi. Bør fylles ut hvis code.coding[LokaltLegemiddel] har verdi."
+* ingredient ^comment = "For legemidler identifisert med FEST-koder (FestLegemiddeldose, FestLegemiddelMerkevare, FestLegemiddelpakning, FestVirkestoff, Varenummer) eller SNOMED CT er ingredient valgfritt, da virkestoffinformasjon kan hentes fra disse katalogene. For lokale legemidler anbefales det å oppgi ingredient for bedre sporbarhet."
+* ingredient.item[x] only Reference or CodeableConcept
+* ingredient.itemReference only Reference($LMDISubstance or $LMDIMedication)
+* ingredient.itemCodeableConcept from LegemiddelKoder (preferred)
+
+
+// EKSEMPLER
+Instance: Legemiddel-Oksykodon-FEST-Virkestoff
+InstanceOf: Legemiddel
+Description: "Eksempel på legemiddel"
+// "Oxycodone Orifarm mikst oppl 1 mg/ml"
+* identifier.system = "http://dmp.no/fhir/NamingSystem/festLegemiddelVirkestoff"
+* identifier.value = "C31AF94A-5D5A-4C91-9B99-BB221E26E4C9"
+* extension[classification].valueCodeableConcept = $ATC#N02AA05 "Oksykodon"
+* code.coding[FestVirkestoff].system = "http://dmp.no/fhir/NamingSystem/festLegemiddelVirkestoff"
+* code.coding[FestVirkestoff].code = #C31AF94A-5D5A-4C91-9B99-BB221E26E4C9
+* code.coding[FestVirkestoff].display = "Oksykodon"
+* form.coding[OID7448].system = "urn:oid:2.16.578.1.12.4.1.1.7448"
+* form.coding[OID7448].code = #51
+* form.coding[OID7448].display = "Mikstur, oppløsning"
+
+Instance: Legemiddel-Paracetamol-FEST-Merkevare
+InstanceOf: Legemiddel
+Description: "Eksempel på legemiddel - Paracetamol"
+* identifier.system = "http://dmp.no/fhir/NamingSystem/festLegemiddelMerkevare"
+* identifier.value = "2ABAC272-0BCF-43F0-84BE-984074D92E15"
+* extension[classification].valueCodeableConcept = $ATC#N02BE01 "Paracetamol"
+* code.coding[FestLegemiddelMerkevare].system = "http://dmp.no/fhir/NamingSystem/festLegemiddelMerkevare"
+* code.coding[FestLegemiddelMerkevare].code = #2ABAC272-0BCF-43F0-84BE-984074D92E15
+* code.coding[FestLegemiddelMerkevare].display = "Paracetamol"
+* form.coding[OID7448].system = "urn:oid:2.16.578.1.12.4.1.1.7448"
+* form.coding[OID7448].code = #1
+* form.coding[OID7448].display = "Tablett"
+
+Instance: Legemiddel-Monoket-FEST-Pakning
+InstanceOf: Legemiddel
+Description: "Eksempel på legemiddel - paking"
+* identifier.system = "http://dmp.no/fhir/NamingSystem/festLegemiddelPakning"
+* identifier.value = "0003602E-315E-4CDE-9EB0-6756BE9CD120"
+* extension[classification].valueCodeableConcept = $ATC#C01DA14 "isosorbide mononitrate"
+* code.coding[FestLegemiddelpakning].system = "http://dmp.no/fhir/NamingSystem/festLegemiddelPakning"
+* code.coding[FestLegemiddelpakning].code = #0003602E-315E-4CDE-9EB0-6756BE9CD120
+* code.coding[FestLegemiddelpakning].display = "Monoket"
+* form.coding[OID7448].system = "urn:oid:2.16.578.1.12.4.1.1.7448"
+* form.coding[OID7448].code = #68
+* form.coding[OID7448].display = "Depottablett"
+
+Instance: Legemiddel-Lokalt-Med-Flere-Ingredienser
+InstanceOf: Legemiddel
+Description: "Eksempel på lokalt legemiddel med flere ingredienser"
+* code.coding[LokaltLegemiddel].system = "http://fh.no/fhir/NamingSystem/lokaltVirkemiddel"
+* code.coding[LokaltLegemiddel].code = #lokal-ketamin-deksametason-haloperidol-klonidin-midazolam-ondansetron
+* code.coding[LokaltLegemiddel].display = "Lokalt legemiddel med ketamin, deksametason, haloperidol, klonidin, midazolam og ondansetron"
+* ingredient[0].itemCodeableConcept.text = "Ketamin"
+* ingredient[0].strength.numerator.value = 10
+* ingredient[0].strength.numerator.system = "http://unitsofmeasure.org"
+* ingredient[0].strength.numerator.code = #mg
+* ingredient[0].strength.denominator.value = 1
+* ingredient[0].strength.denominator.system = "http://unitsofmeasure.org"
+* ingredient[0].strength.denominator.code = #1
+* ingredient[1].itemCodeableConcept.text = "Deksametason"
+* ingredient[1].strength.numerator.value = 4
+* ingredient[1].strength.numerator.system = "http://unitsofmeasure.org"
+* ingredient[1].strength.numerator.code = #mg
+* ingredient[1].strength.denominator.value = 1
+* ingredient[1].strength.denominator.system = "http://unitsofmeasure.org"
+* ingredient[1].strength.denominator.code = #1
+* ingredient[2].itemCodeableConcept.text = "Haloperidol"
+* ingredient[2].strength.numerator.value = 5
+* ingredient[2].strength.numerator.system = "http://unitsofmeasure.org"
+* ingredient[2].strength.numerator.code = #mg
+* ingredient[2].strength.denominator.value = 1
+* ingredient[2].strength.denominator.system = "http://unitsofmeasure.org"
+* ingredient[2].strength.denominator.code = #1
+* ingredient[3].itemCodeableConcept.text = "Klonidin"
+* ingredient[3].strength.numerator.value = 150
+* ingredient[3].strength.numerator.system = "http://unitsofmeasure.org"
+* ingredient[3].strength.numerator.code = #ug
+* ingredient[3].strength.denominator.value = 1
+* ingredient[3].strength.denominator.system = "http://unitsofmeasure.org"
+* ingredient[3].strength.denominator.code = #1
+* ingredient[4].itemCodeableConcept.text = "Midazolam"
+* ingredient[4].strength.numerator.value = 5
+* ingredient[4].strength.numerator.system = "http://unitsofmeasure.org"
+* ingredient[4].strength.numerator.code = #mg
+* ingredient[4].strength.denominator.value = 1
+* ingredient[4].strength.denominator.system = "http://unitsofmeasure.org"
+* ingredient[4].strength.denominator.code = #1
+* ingredient[5].itemCodeableConcept.text = "Ondansetron"
+* ingredient[5].strength.numerator.value = 2
+* ingredient[5].strength.numerator.system = "http://unitsofmeasure.org"
+* ingredient[5].strength.numerator.code = #mg
+* ingredient[5].strength.denominator.value = 1
+* ingredient[5].strength.denominator.system = "http://unitsofmeasure.org"
+* ingredient[5].strength.denominator.code = #1
+
+// Invarianter
+Invariant: lmdi-medication-code-or-ingredient
+Description: "Medication skal ha code.coding eller ingredient"
+Severity: #error
+Expression: "code.coding.exists() or ingredient.exists()"

--- a/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-MedicationAdministration.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-MedicationAdministration.fsh
@@ -1,0 +1,154 @@
+Profile: Legemiddeladministrering
+Parent: MedicationAdministration
+Id: lmdi-medicationadministration
+Title: "Legemiddeladministrering"
+Description: """Beskriver administrering av legemiddel til pasient på institusjon.
+
+Dette er kjerneressursen for denne implementasjonsguiden. Den peker videre til legemiddelet som ble gitt, pasienten som har fått administrert legemiddel, på hvilken institusjon det skjedde, tidspunkt for administrering og dose med eventuell administrasjonsvei."""
+
+* ^status = #draft
+* ^date = "2025-09-12"
+* ^publisher = "Folkehelseinstituttet"
+
+// Core Elements
+* subject only Reference(Pasient)
+* subject ^short = "Hvem fikk legemidlet (pasient)"
+* subject ^definition = "Det skal alltid være en referanse til pasienten som har blitt administrert legemiddel."
+
+* medication[x] only Reference(Legemiddel)
+* medication[x] ^short = "Legemiddel"
+
+* status from LegemiddeladministreringStatus
+* status ^short = "Status administrering (completed | entered-in-error)"
+* status ^definition = "Status administrering. Skal vanligvis settes til 'Gjennomført' (completed), men 'Feilregistrert' (entered-in-error) MÅ benyttes hvis registreringen inneholder en alvorlig feil og skal slettes."
+
+// Timing Elements
+* effective[x] ^short = "Tidspunktet eller periode legemidlet ble administrert"
+* effective[x] only Period or dateTime
+* effective[x] 1..1
+* effectiveDateTime obeys time-required
+* effectivePeriod.start 1..1
+* effectivePeriod.end 1..1
+* effectivePeriod.start obeys time-required
+* effectivePeriod.end obeys time-required
+
+// Context and References
+* context MS
+* context only Reference(Episode)
+* context ^short = "Episoden (f.eks. konsultasjonen/innleggelsen) som legemidlet ble administrert i forbindelse med."
+* context ^definition = "Referanse til hvilket institusjonsopphold eller avtale pasienten var på da legemiddelet ble administrert."
+
+* reasonCode ^short = "Årsak til utført administrering (Given as Ordered, Emergency, None)"
+
+* request MS
+* request only Reference(Legemiddelrekvirering)
+* request ^short = "Referanse til rekvireringen"
+* request ^definition = "Referanse til rekvireringen som denne administreringen er basert på."
+
+* reasonReference only Reference(Diagnose)
+* reasonReference ^short = "Indikasjon (diagnose) for legemiddeladministreringen"
+
+// Dosage Information
+* dosage.route MS
+* dosage.route ^short = "Administrasjonsvei"
+* dosage.route ^definition = "Administrasjonsvei. Er begrenset til foreslått koding fra SNOMED CT-verdisettet til HL7 og Volven-kodeverket Administrasjonsvei (OID=7477) fra eResept."
+* dosage.route ^comment = "Administrasjonsvei benyttes for å angi hvordan legemiddelet ble gitt."
+
+* dosage.route.coding ^slicing.discriminator.type = #pattern
+* dosage.route.coding ^slicing.discriminator.path = "system"
+* dosage.route.coding ^slicing.rules = #closed
+* dosage.route.coding 1..*
+* dosage.route.coding contains SCT 0..1 and OID7477 0..1
+
+* dosage.route.coding[SCT] ^short = "SNOMED CT"
+* dosage.route.coding[SCT] ^definition = "Administrasjonsvei kodet med SNOMED CT, hentet fra verdisett foreslått av HL7."
+* dosage.route.coding[SCT].system = "http://snomed.info/sct"
+* dosage.route.coding[SCT].code 1..1
+* dosage.route.coding[SCT].code from http://hl7.org/fhir/ValueSet/route-codes (required)
+
+* dosage.route.coding[OID7477] ^short = "Administrasjonsvei (OID=7477)"
+* dosage.route.coding[OID7477] ^definition = "Administrasjonsvei (OID=7477) fra kodeverkssamling Resept."
+* dosage.route.coding[OID7477].system = "urn:oid:2.16.578.1.12.4.1.1.7477"
+* dosage.route.coding[OID7477].code 1..1
+* dosage.route.coding[OID7477].code ^short = "Verdi fra kodeverket"
+* dosage.route.coding[OID7477].display ^short = "Beskrivelse av koden (navn) fra kodeverket"
+
+* dosage.dose 1..1
+* dosage.dose ^short = "Administrert mengde virkestoff"
+* dosage.dose ^definition = "Mengde (dosering) av legemiddelets primære virkestoff."
+
+* dosage.rateRatio MS
+
+// Disabled Elements
+* device 0..0
+* note 0..0
+* partOf 0..0
+* performer 0..0
+* supportingInformation 0..0
+* text 0..0
+* eventHistory 0..0
+* dosage.text 0..0
+* dosage.route.text 0..0
+
+// =========================================
+// Invariant Definition
+// =========================================
+Invariant: time-required
+Description: "Må inneholde tidspunkt for administrering."
+Severity: #error
+Expression: "$this.toString().matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}.*$')"
+
+// =========================================
+// ValueSet Definition
+// =========================================
+ValueSet: LegemiddeladministreringStatus
+Id: lmdi-medicationadministrationstatus
+Title: "Status for legemiddeladministrering"
+Description: "Verdisett som begrenses status til Legemiddeladministrering til henholdsvis 'Gjennomført' eller 'Feilregistrert'."
+* ^status = #draft
+* ^date = "2025-09-12"
+* ^publisher = "Folkehelseinstituttet"
+* http://terminology.hl7.org/CodeSystem/medication-admin-status#completed "Gjennomført"
+* http://terminology.hl7.org/CodeSystem/medication-admin-status#entered-in-error "Feilregistrert"
+
+// =========================================
+// Examples
+// =========================================
+Instance: Administrering-Oral
+InstanceOf: Legemiddeladministrering
+Description: "Eksempel på administrering av legemiddel"
+* status = #completed
+* medicationReference = Reference(https://fhir.legemidler.example.com/legemidler/123456780)
+* subject = Reference(https://fhi.no/fhir/lmdi/pasient/12345678)
+* context = Reference(https://fhi.no/fhir/lmdi/episode/428ff23d-7a65-4c67-8059-6a1d07d287e3)
+* effectiveDateTime = "2024-05-28T09:30:00+02:00"
+* dosage.route.coding[SCT].system = "http://snomed.info/sct"
+* dosage.route.coding[SCT].code = #421521009
+* dosage.route.coding[SCT].display = "Swallow"
+* dosage.dose.value = 10.0
+* dosage.dose.unit = "mg"
+* dosage.dose.system = "http://unitsofmeasure.org"
+* dosage.dose.code = #mg
+
+Instance: Administrering-Infusjon
+InstanceOf: Legemiddeladministrering
+Description: "Eksempel på administrering av legemiddel - infusjon"
+* status = #completed
+* medicationReference = Reference(https://fhir.legemidler.example.com/legemidler/0987654321)
+* subject = Reference(https://fhi.no/fhir/lmdi/pasient/12345678)
+* context = Reference(https://fhi.no/fhir/lmdi/institusjonsopphold/428ff23d-7a65-4c67-8059-6a1d07d287e3)
+* effectivePeriod.start = "2024-06-13T14:26:01+02:00"
+* effectivePeriod.end = "2024-06-13T14:48:47+02:00"
+* dosage.route.coding[SCT].system = "http://snomed.info/sct"
+* dosage.route.coding[SCT].code = #47625008
+* dosage.route.coding[SCT].display = "Intravenous route (qualifier value)"
+* dosage.dose.value = 4500
+* dosage.dose.unit = "mg"
+* dosage.dose.system = "http://unitsofmeasure.org"
+* dosage.dose.code = #mg
+* dosage.rateRatio.numerator.value = 8.0
+* dosage.rateRatio.numerator.system = "http://unitsofmeasure.org"
+* dosage.rateRatio.numerator.code = #mL
+* dosage.rateRatio.denominator.value = 1
+* dosage.rateRatio.denominator.system = "http://unitsofmeasure.org"
+* dosage.rateRatio.denominator.code = #min

--- a/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-MedicationRequest.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-MedicationRequest.fsh
@@ -1,0 +1,113 @@
+Profile: Legemiddelrekvirering
+Parent: MedicationRequest
+Id: lmdi-medicationrequest
+Title: "Legemiddelrekvirering"
+Description: "Legemiddelrekvirering - ordinering eller annen rekvirering av legemiddel"
+
+// Metadata
+* ^status = #draft
+* ^date = "2025-09-12"
+* ^publisher = "Folkehelseinstituttet"
+
+
+// Extensions for Legemiddelrekvirering
+* extension contains ProsentvisDoseendring named prosentvisDoseendring 0..1
+* extension[prosentvisDoseendring] ^short = "Doseendring i prosent"
+* extension[prosentvisDoseendring] ^definition = "Doseendring i prosent, sammenlignet med opprinnelig dosering. Spesielt relevant ved kjemoterapi. Kan ha verdier fra 0. Ved vanlig dose uten endring er doseendring 100 (%). Enhet skal være prosent."
+
+* extension contains DelAvBehandlingsregime named delAvBehandlingsregime 0..1
+* extension[delAvBehandlingsregime] ^short = "Del av behandlingsregime"
+* extension[delAvBehandlingsregime] ^definition = "Navnet på kuren, behandlingsregimet eller protokollen legemidlet gis som en del av. Spesielt relevant ved kjemoterapi."
+
+* extension contains KliniskStudie named kliniskStudie 0..1
+* extension[kliniskStudie] ^short = "Legemiddel i klinisk studie"
+* extension[kliniskStudie] ^definition = "Angir om legemidlet gis som en del av en klinisk studie."
+
+
+// Deaktiverte elementer
+* text 0..0
+* recorder 0..0
+* insurance 0..0
+* supportingInformation 0..0
+* performer 0..0
+* performerType 0..0
+* basedOn 0..0
+* note 0..0
+* dispenseRequest 0..0
+* detectedIssue 0..0
+* eventHistory 0..0
+* dosageInstruction.text 0..0
+* dosageInstruction.patientInstruction 0..0
+
+// Identifikator
+* identifier 0..* MS
+* identifier ^short = "Identifikator for rekvirering"
+* identifier ^definition = "Must Support: En identifikator som unikt identifiserer en rekvirering må oppgis om en slik finnes"
+
+// Status og intensjon
+* status 1..1 MS
+* status ^short = "Status for rekvireringen"
+* status ^definition = "Must Support: Status er viktig for å kunne følge livssyklusen til en rekvirering og må støttes av alle systemer"
+* status from http://hl7.org/fhir/ValueSet/medicationrequest-status
+* status ^comment = "Gyldige verdier: active | on-hold | cancelled | completed | entered-in-error | stopped | draft"
+
+* intent 1..1 MS
+* intent ^short = "Intensjonen eller hensikten med rekvireringen: proposal | plan | order | original-order | reflex-order | filler-order | instance-order | option"
+
+// Referanser til andre ressurser
+* medication[x] only Reference(Legemiddel)
+* medication[x] 1..1 MS
+* medication[x] ^short = "Legemidlet som er rekvirert"
+
+* subject 1..1 MS
+* subject only Reference(Pasient)
+* subject ^short = "Pasienten legemidlet er rekvirert til"
+
+* requester 1..1 MS
+* requester only Reference(Helsepersonell)
+* requester ^short = "Helsepersonellet som rekvirerte legemidlet"
+
+* reasonReference only Reference(Diagnose)
+* reasonReference ^short = "Indikasjon (diagnose) for legemiddelrekvireringen"
+
+* priorPrescription only Reference(Legemiddelrekvirering)
+
+* encounter only Reference(Episode)
+* encounter ^short = "Episoden (f.eks. konsultasjonen/innleggelsen) som legemidlet ble rekvirert i forbindelse med."
+
+* courseOfTherapyType ^short = "Type behandlingsforløp (continuous | acute | seasonal)"
+
+// Andre elementer
+* reported[x] only boolean
+
+// Kommentarer
+//  priorPrescription må referere til Legemiddelrekvirering
+
+// EKSEMPEL
+Instance: Rekvirering-Paracetamol
+InstanceOf: Legemiddelrekvirering
+Description: "Eksempel på legemiddelrekvirering av Paracet"
+* identifier.system = "http://example.org/rekvirering-id"
+* identifier.value = "REK123456"
+* status = #active
+* intent = #order
+* medicationReference = Reference(Legemiddel-Paracetamol-FEST-Merkevare)
+* subject = Reference(Pasient-Med-FNR)
+* requester = Reference(Helsepersonell-Med-HPR)
+* authoredOn = "2025-01-27"
+
+Instance: Rekvirering-Kjemoterapi
+InstanceOf: Legemiddelrekvirering
+Description: "Eksempel på kjemoterapirekvirering med doseendring, behandlingsregime og klinisk studie"
+* status = #active
+* intent = #order
+* medicationReference = Reference(Legemiddel-Oksykodon-FEST-Virkestoff)
+* subject = Reference(Pasient-Med-FNR)
+* requester = Reference(Helsepersonell-Med-HPR)
+* authoredOn = "2025-03-10"
+* extension[prosentvisDoseendring].valueQuantity.value = 80
+* extension[prosentvisDoseendring].valueQuantity.system = "http://unitsofmeasure.org"
+* extension[prosentvisDoseendring].valueQuantity.code = #%
+* extension[prosentvisDoseendring].valueQuantity.unit = "%"
+* extension[delAvBehandlingsregime].valueString = "FOLFOX6"
+* extension[kliniskStudie].valueBoolean = true

--- a/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-Organization.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-Organization.fsh
@@ -1,0 +1,144 @@
+// Hoveddefinisjon av organisasjonsprofil
+Profile: Organisasjon
+Parent: NoBasisOrganization
+Id: lmdi-organization
+Title: "Organisasjon"
+Description: """
+Organisasjoner i norsk helse- og omsorgstjeneste, som post, avdeling, klinikk, sykehus og sykehjem, basert på no-basis-Organization.
+
+Denne profilen av Organization benyttes for å beskrive helseinstitusjoner og skal representere organisasjonen på lavest mulig nivå i organisasjonshierarkiet (f.eks. en avdeling eller klinikk eller post). For organisasjonen som er del av en større organisasjon, skal dette angis ved hjelp av partOf-relasjonen.
+
+Det er ønskelig at minimum følgende inngår i "organisasjonshierarkiet":
+- organisasjonen på lavest mulig nivå (dvs. post, enhet, avdeling eller lignende)
+- organisasjonen på høyre nivå
+     - sykehus, Helseforetak og Regionalt Helseforetak
+     - sykehjem, kommune
+- minst ett organisasjonsnummer fra enten Enhetsregisteret (identifier:ENH) eller Register for enheter i spesialisthelsetjenesten (identifier:RSH)
+"""
+* ^status = #draft
+* ^date = "2025-09-30"
+* ^publisher = "Folkehelseinstituttet"
+
+// Sikkerhetsinvariant: minst ENH eller RSH identifier
+* obeys lmdi-org-identifier
+
+// Deaktiverte felter
+* text 0..0
+* active 0..0
+* telecom 0..0
+* contact 0..0
+* endpoint 0..0
+* address.text 0..0
+* address.line 0..0
+* address.city 0..0
+* address.postalCode 0..0
+
+// Identifikatorer - bruker no-basis sine eksisterende slices (arver slicing fra parent)
+* identifier 0..* MS
+* identifier ^short = "ID fra Nasjonalt register for enheter i spesialisthelsetjenesten (RESH) eller Organisasjonsnummeret i Enhetsregister"
+* identifier ^comment = "Der aktiviteten har skjedd."
+
+* identifier[ENH] ^short = "Organisasjonsnummer fra Enhetsregisteret (ENH)"
+* identifier[ENH] ^comment = "Identifikatorer skal angis på laveste relevante virksomhetsnivå i henhold til SSBs retningslinjer. For kommunale tjenester betyr dette på institusjonsnivå (f.eks sykehjem) der egen organisatorisk enhet er etablert, ikke på overordnet kommunenivå."
+
+* identifier[RSH] ^short = "ID fra Register for enheter i spesialisthelsetjenesten (RESH)"
+* identifier[RSH] ^comment = "Det nivået aktiviteten har skjedd på."
+
+// Organisasjonstype og navn - bruker no-basis slices
+* type 0..*
+* type ^short = "Organisasjonstype"
+* type ^definition = "Type organisasjon (f.eks. sykehus, avdeling, klinikk)"
+* type[organisatoriskNiva] 0..0
+// LMDI deaktiverer organisatoriskNiva fordi kodeverket (OID 8628) ikke lenger er i bruk.
+// organisatoriskBetegnelse beholdes fra no-basis og brukes i eksemplene.
+
+* name 1..1 MS
+* name ^short = "Organisasjonsnavn"
+* name ^definition = "Offisielt navn på organisasjonen"
+* name ^comment = "Kan være navn på post, avdelingsnavn, klinikknavn, sykehusnavn eller sykehjemsnavn"
+
+// Hierarkisk struktur
+* partOf MS
+* partOf ^short = "Organisasjonen er del av (overordnet organisasjon)"
+* partOf ^definition = "Organisasjonen er del av (overordnet organisasjon)"
+* partOf only Reference(Organisasjon)
+
+// Adresse
+* address MS
+* address ^short = "Gjeldende fysisk adresse"
+* address.extension[official] 0..0
+* address.extension[propertyInformation] 0..0
+* address.type = #physical
+* address.type from LmdiAddressType (required)
+* address.type ^short = "physical"
+
+* address.district ^short = "Kommune"
+// Bruker no-basis-municipalitycode extension som allerede er definert
+* address.district.extension[municipalitycode] ^short = "Kodet verdi for kommune. Kodeverk \"Kommunenummer og regionale spesialkoder\" (OID 3402)"
+* address.district.extension[municipalitycode] ^definition = "Kodet verdi for kommune. Koder fra kodeverk \"Kommunenummer og regionale spesialkoder\" (OID 3402) skal benyttes"
+
+* address.state ^short = "Fylkesnavn"
+* address.country 0..0
+
+* address.extension[urbanDistrict] ^short = "Kodet verdi for bydel. Kodeverk \"Bydelsnummer\" (OID 3403)"
+* address.extension[urbanDistrict] ^definition = "Kodet verdi for bydel. Koder fra kodeverk \"Bydelsnummer\" (OID 3403) skal benyttes"
+
+// EKSEMPLER
+
+Instance: Organisasjon-Kommune
+InstanceOf: Organisasjon
+Description: "Eksempel på kommune i primærhelsetjenesten"
+* identifier[ENH].system = "urn:oid:2.16.578.1.12.4.1.4.101"
+* identifier[ENH].value = "942110464"
+* name = "TRONDHEIM KOMMUNE"
+* address.type = #physical
+* address.district = "Trondheim"
+* address.district.extension[municipalitycode].valueCoding = $kommunenummer-alle#5001 "Trondheim - Tråante"
+
+Instance: Organisasjon-Sykehjem
+InstanceOf: Organisasjon
+Description: "Eksempel på sykehjem i primærhelsetjenesten"
+* identifier[ENH].system = "urn:oid:2.16.578.1.12.4.1.4.101"
+* identifier[ENH].value = "985626154"
+* name = "BYNESET OG NYPANTUNET HELSE- OG VELFERDSSENTER SYKEHJEM"
+* partOf = Reference(Organisasjon-Kommune)
+* address.type = #physical
+* address.district = "Trondheim"
+* address.district.extension[municipalitycode].valueCoding = $kommunenummer-alle#5001 "Trondheim - Tråante"
+
+Instance: Organisasjon-HF
+InstanceOf: Organisasjon
+Description: "Eksempel på Helseforetak"
+* identifier[ENH].system = "urn:oid:2.16.578.1.12.4.1.4.101"
+* identifier[ENH].value = "993467049"
+* identifier[RSH].system = "urn:oid:2.16.578.1.12.4.1.4.102"
+* identifier[RSH].value = "4001031"
+* name = "Oslo universitetssykehus HF"
+
+Instance: Organisasjon-Sykehus
+InstanceOf: Organisasjon
+Description: "Eksempel på sykehusorganisasjon"
+* identifier[ENH].system = "urn:oid:2.16.578.1.12.4.1.4.101"
+* identifier[ENH].value = "974705761"
+* name = "OSLO UNIVERSITETSSYKEHUS HF SPESIALSYKEHUSET FOR EPILEPSI SSE - SOMATIKK"
+* type[organisatoriskBetegnelse].coding = $organisatoriskBetegnelse#01 "Sykehus"
+* partOf = Reference(Organisasjon-HF)
+* address.type = #physical
+* address.district.extension[municipalitycode].valueCoding = $kommunenummer-alle#3201 "Bærum"
+
+Instance: Organisasjon-Sykehusavdeling
+InstanceOf: Organisasjon
+Description: "Eksempel på spesialistavdeling"
+* identifier[RSH].system = "urn:oid:2.16.578.1.12.4.1.4.102"
+* identifier[RSH].value = "4208723"
+* name = "Avdeling for epilepsi, poliklinikk"
+* type[organisatoriskBetegnelse].coding = $organisatoriskBetegnelse#05 "Avdeling"
+* partOf = Reference(Organisasjon-Sykehus)
+* address.type = #physical
+* address.district.extension[municipalitycode].valueCoding = $kommunenummer-alle#3201 "Bærum"
+
+// Invariant definisjon
+Invariant: lmdi-org-identifier
+Description: "Organisasjon skal ha minst ENH eller RSH identifier"
+Severity: #error
+Expression: "identifier.where(system='urn:oid:2.16.578.1.12.4.1.4.101' or system='urn:oid:2.16.578.1.12.4.1.4.102').exists()"

--- a/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-Patient.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-Patient.fsh
@@ -1,0 +1,114 @@
+Profile: Pasient
+Id: lmdi-patient
+Parent: NoBasisPatient
+Title: "Pasient"
+Description: "Pasienten som har fått rekvirert eller administrert legemiddel, basert på no-basis-Patient"
+* ^status = #draft
+* ^date = "2025-09-30"
+* ^publisher = "Folkehelseinstituttet"
+
+// Deaktiverte felter
+* active 0..0
+* communication 0..0
+* contact 0..0
+* deceased[x] 0..0
+* generalPractitioner 0..0
+* link 0..0
+* managingOrganization 0..0
+* maritalStatus 0..0
+* multipleBirth[x] 0..0
+* name 0..0
+* photo 0..0
+* telecom 0..0
+* text 0..0
+* extension[citizenship] 0..0
+
+// Adresse - bruker no-basis-Address
+* address MS
+* address only NoBasisAddress
+* address.extension[official] 0..0
+* address.extension[propertyInformation] 0..0
+* address.type = #physical
+* address.type from LmdiAddressType (required)
+* address.type ^short = "physical"
+* address.city 0..0
+* address.text 0..0
+* address.line 0..0
+* address.district ^short = "Kommune"
+// Bruker no-basis-municipalitycode extension
+* address.district.extension[municipalitycode] ^short = "Kodet verdi for kommune. Kodeverk \"Kommunenummer og regionale spesialkoder\" (OID 3402)"
+* address.district.extension[municipalitycode] ^definition = "Kodet verdi for kommune. Koder fra kodeverk \"Kommunenummer og regionale spesialkoder\" (OID 3402) skal benyttes"
+* address.use from LmdiAddressUse (required)
+* address.use ^binding.description = "Tillatte verdier er home, temp eller old"
+* address.use ^short = "home | temp | old"
+* address.use ^definition = "Adressetype begrenset til home, temp eller old"
+* address.state ^short = "Fylkesnavn"
+* address.country 0..0
+* address.postalCode 0..0
+
+* address.extension[urbanDistrict] ^short = "Kodet verdi for bydel. Kodeverk \"Bydelsnummer\" (OID 3403)"
+* address.extension[urbanDistrict] ^definition = "Kodet verdi for bydel. Koder fra kodeverk \"Bydelsnummer\" (OID 3403) skal benyttes"
+// Fødselsdato
+* birthDate MS
+* birthDate ^short = "Fødselsdato"
+* birthDate ^definition = "Pasientens fødselsdato."
+
+// Kjønn
+* gender MS
+* gender ^short = "Kjønn"
+* gender ^definition = "Pasientens kjønn."
+
+// Identifikatorer - bruker no-basis slices
+* identifier MS
+* identifier ^short = "Identifikator for pasienten."
+* identifier ^definition = "Identifikator for pasienten. Bør være fødselsnummer (FNR) eller D-nummer (DNR) når tilgjengelig."
+
+// Bruker no-basis sine eksisterende slices
+* identifier[FNR] 0..1 MS
+* identifier[FNR] ^short = "Fødselsnummer"
+* identifier[FNR].value 1..1
+* identifier[FNR].value ^short = "Fødselsnummeret (11 siffer)"
+* identifier[FNR].value ^example[0].label = "Fødselsnummer"
+* identifier[FNR].value ^example[0].valueString = "12345678901"
+
+* identifier[DNR] 0..1 MS
+* identifier[DNR] ^short = "D-nummer"
+* identifier[DNR].value 1..1
+* identifier[DNR].value ^short = "D-nummer (11 siffer)"
+* identifier[DNR].value ^example[0].label = "D-nummer"
+* identifier[DNR].value ^example[0].valueString = "12345678901"
+
+// Skjul no-basis slices som LMDI ikke bruker
+* identifier[FHN] 0..0
+* identifier[HNR] 0..0
+
+// EKSEMPLER
+Instance: Pasient-Uten-Personidentifikator
+InstanceOf: Pasient
+Description: "Eksempel på pasient uten personidentifikator"
+* gender = #female
+* birthDate = "1958-09-19"
+* address.district = "Bærum"
+* address.district.extension[municipalitycode].valueCoding = $kommunenummer-alle#3024 "Bærum"
+
+Instance: Pasient-Med-FNR
+InstanceOf: Pasient
+Description: "Eksempel på pasient med fødselsnummer"
+* identifier[FNR].system = "urn:oid:2.16.578.1.12.4.1.4.1"
+* identifier[FNR].value = "12705825562"
+* gender = #male
+* birthDate = "1958-05-12"
+* address.use = #home
+* address.type = #physical
+* address.district = "Oslo"
+* address.district.extension[municipalitycode].valueCoding = $kommunenummer-alle#0301 "Oslo"
+* address.extension[urbanDistrict].valueCoding = $VsLmdiUrbanDistrict#030102 "Grünerløkka"
+
+Instance: Pasient-Med-DNR
+InstanceOf: Pasient
+Description: "Eksempel på pasient med D-nummer"
+* identifier[DNR].system = "urn:oid:2.16.578.1.12.4.1.4.2"
+* identifier[DNR].value = "41667987421"
+* birthDate = "1979-01-01"
+* address.state = "Vestland"
+

--- a/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-Practitioner.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-Practitioner.fsh
@@ -1,0 +1,55 @@
+Profile: Helsepersonell
+Id: lmdi-practitioner
+Parent: NoBasisPractitioner
+Title: "Helsepersonell"
+Description: "Helsepersonell som har rekvirert legemidlet, basert på no-basis-Practitioner. HPR-nummer skal oppgis når tilgjengelig."
+
+* ^status = #draft
+* ^date = "2025-09-12"
+* ^publisher = "Folkehelseinstituttet"
+
+// === IDENTIFIER HÅNDTERING ===
+// Bruker no-basis slicing med closed slicing for å begrense til kun HPR
+* identifier ^slicing.rules = #closed  // Lukk slicing - kun HPR tillatt
+* identifier ^short = "Helsepersonellnummer (HPR-nummer)"
+* identifier ^definition = "Helsepersonellnummer (HPR-nummer) fra Helsepersonellregisteret. Skal registreres når tilgjengelig."
+
+// Bruk no-basis HPR slice - system er allerede definert i no-basis
+* identifier[HPR] 0..1 MS
+* identifier[HPR] ^short = "HPR-nummer"
+* identifier[HPR] ^definition = "Helsepersonellnummer fra Helsepersonellregisteret."
+
+// Skjul FNR og DNR slices fra no-basis
+* identifier[FNR] 0..0
+* identifier[DNR] 0..0
+
+// Spesialitet
+// * qualification ^short = "Spesialitet"
+// * qualification.code.coding.system 1..1
+// * qualification.code.coding.system = "urn:oid:2.16.578.1.12.4.1.1.7426"
+// * qualification.code.coding.system ^short = "Helsepersonellregisterets (HPR) klassifikasjon av spesialiteter (OID=7426)"
+// * qualification.code.coding.system ^definition = "Dette kodeverket inneholder koder for spesialiteter i Helsepersonellregisteret. Kilde: Forskrift om spesialistgodkjenning av helsepersonell og turnusstillinger for leger."
+// * qualification.code.coding.system ^comment = "MVP - satt til HPR-spesialieter (OID=7426)."
+
+// Deaktiverte elementer
+* text 0..0
+* name 0..0
+* telecom 0..0
+* address 0..0
+* gender 0..0
+* birthDate 0..0
+* photo 0..0
+* qualification 0..0
+* communication 0..0
+* active 0..0
+
+Instance: Helsepersonell-Med-HPR
+InstanceOf: Helsepersonell
+Description: "Eksempel på helsepersonell med HPR-nummer"
+* identifier[HPR].system = "urn:oid:2.16.578.1.12.4.1.4.4"
+* identifier[HPR].value = "9144900"
+
+Instance: Helsepersonell-Uten-HPR
+InstanceOf: Helsepersonell
+Description: "Eksempel på rekvirent uten HPR-nummer"
+// Ingen identifier - gyldig da identifier er valgfri (0..*)

--- a/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-Substance.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/profiles/lmdi-Substance.fsh
@@ -1,0 +1,25 @@
+Profile: Virkestoff
+Id: lmdi-substance
+Parent: NoBasisSubstance
+Title: "Virkestoff"
+Description: "En tilpasset profil av Substance for å representere virkestoff, basert på no-basis."
+
+* ^status = #draft
+* ^date = "2025-09-12"
+* ^publisher = "Folkehelseinstituttet"
+
+* text 0..0
+* description 0..0
+* ingredient 0..0
+* category 1..1
+
+// EKSEMPLER
+Instance: Virkestoff-Oksykodon
+InstanceOf: Virkestoff
+Description: "Eksempel på virkestoff - Oksykodon"
+* code.coding.system = "http://snomed.info/sct"
+* code.coding.code = #55452001
+* code.coding.display = "Oxycodone (substance)"
+* category.coding.system = "http://terminology.hl7.org/CodeSystem/substance-category"
+* category.coding.code = #drug
+* category.coding.display = "Drug or Medicament"

--- a/.claude/skills/lmdi-fhir/references/fsh/valuesets/lmdi-ATCValueSet.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/valuesets/lmdi-ATCValueSet.fsh
@@ -1,0 +1,12 @@
+ValueSet: ATCValueSet
+Id: atc-valueset
+Title: "ATC Kodesystem ValueSet"
+Description: "ValueSet som inneholder koder fra WHO ATC (Anatomisk Terapeutisk Kjemisk legemiddelregister)"
+* ^url = "http://fhir.no/ValueSet/atc-valueset"
+* ^status = #active
+* ^date = "2025-09-12"
+* ^publisher = "Folkehelseinstituttet"
+* ^contact.name = "Folkehelseinstituttet"
+* ^contact.telecom.system = #url
+* ^contact.telecom.value = "https://www.fhi.no"
+* include codes from system http://www.whocc.no/atc

--- a/.claude/skills/lmdi-fhir/references/fsh/valuesets/lmdi-LegemiddelKoderValueSet.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/valuesets/lmdi-LegemiddelKoderValueSet.fsh
@@ -1,0 +1,12 @@
+ValueSet: LegemiddelKoder 
+Id: legemiddel-koder 
+Title: "Gyldige legemiddelkoder" 
+Description: "ValueSet som inneholder koder fra SNOMED CT, FEST, LMR-nummer, varenummer og lokal legemiddelkatalog"
+* include codes from system http://snomed.info/sct
+* include codes from system http://dmp.no/fhir/NamingSystem/festLegemiddelMerkevare 
+* include codes from system http://dmp.no/fhir/NamingSystem/festLegemiddelVirkestoff 
+* include codes from system http://dmp.no/fhir/NamingSystem/festLegemiddelPakning 
+* include codes from system http://dmp.no/fhir/NamingSystem/festLegemiddelDose
+* include codes from system http://dmp.no/fhir/NamingSystem/lmrLopenummer
+* include codes from system http://dmp.no/fhir/NamingSystem/fest-varenummer
+* include codes from system http://fh.no/fhir/NamingSystem/lokaltVirkemiddel

--- a/.claude/skills/lmdi-fhir/references/fsh/valuesets/lmdi-LokalLegemiddelKatalogValues.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/valuesets/lmdi-LokalLegemiddelKatalogValues.fsh
@@ -1,0 +1,10 @@
+CodeSystem: LokalLegemiddelkatalogCodeSystem
+Title: "Lokal Legemiddelkatalog Codes"
+Description: "Kodesystem for lokal legemiddelkatalog"
+* #metavisionkatalogFraHso "MetavisionkatalogFraHso" "Metavisionkatalog fra Helse Sør-Øst"
+* #metavisionkatalogFraHN "MetavisionkatalogFraHN" "Metavisionkatalog fra Helse Nord"
+
+ValueSet: LokalLegemiddelkatalogValues
+Title: "Lokal Legemiddelkatalog Values"
+Description: "Gyldige verdier for lokal legemiddelkatalog"
+* include codes from system LokalLegemiddelkatalogCodeSystem

--- a/.claude/skills/lmdi-fhir/references/fsh/valuesets/lmdi-address-valuesets.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/valuesets/lmdi-address-valuesets.fsh
@@ -1,0 +1,15 @@
+ValueSet: LmdiAddressUse
+Id: lmdi-address-use
+Title: "LMDI Address Use"
+Description: "Tillatte verdier for address.use i LMDI: home, temp, old"
+* ^status = #active
+* include http://hl7.org/fhir/address-use#home
+* include http://hl7.org/fhir/address-use#temp
+* include http://hl7.org/fhir/address-use#old
+
+ValueSet: LmdiAddressType
+Id: lmdi-address-type
+Title: "LMDI Address Type"
+Description: "Tillatt verdi for address.type i LMDI: physical"
+* ^status = #active
+* include http://hl7.org/fhir/address-type#physical

--- a/.claude/skills/lmdi-fhir/references/fsh/valuesets/lmdi-kommunenummer-alle.fsh
+++ b/.claude/skills/lmdi-fhir/references/fsh/valuesets/lmdi-kommunenummer-alle.fsh
@@ -1,0 +1,14 @@
+ValueSet: KommunenummerValueSet
+Id: kommunenummer-alle
+Title: "Kommunenummer ValueSet"
+Description: "Komplett kodeverk for norske kommunenummer (Volven 3402)"
+* ^status = #active
+* include codes from system KommunenummerCodeSystem
+
+CodeSystem: KommunenummerCodeSystem
+Id: kommunenummer-codesystem
+Title: "Kommunenummer CodeSystem"
+Description: "Kodesystem for norske kommunenummer (Volven 3402)"
+* ^url = "urn:oid:2.16.578.1.12.4.1.1.3402"
+* ^status = #active
+* ^content = #not-present

--- a/.claude/skills/lmdi-fhir/references/sushi-config.yaml
+++ b/.claude/skills/lmdi-fhir/references/sushi-config.yaml
@@ -1,0 +1,83 @@
+# ╭──────────────────────────────────────ImplementationGuide───────────────────────────────────────╮
+# │  The properties below are used to create the ImplementationGuide resource. For a list of       │
+# │  supported properties, see: https://fshschool.org/docs/sushi/configuration/                    │
+# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+id: hl7.fhir.no.lmdi
+canonical: http://hl7.no/fhir/ig/lmdi
+name: Lmdi
+title: "Legemiddeldata fra institusjon til Legemiddelregisteret"
+description: "Denne implementasjongguiden beskriver hvordan institusjoner skal overføre data om legemiddelbruk i institusjoner til Legemiddelregisteret"
+status: draft
+license: CC-BY-4.0
+date: 2026-03-10
+language: no
+version: 1.0.8
+
+fhirVersion: 4.0.1
+
+copyrightYear: 2024+
+releaseLabel: ci-build
+
+publisher:
+  name: Folkehelseinstituttet
+  url: https://www.fhi.no
+contact:
+  - name: Legemiddelregisteret
+    telecom:
+      - system: email
+        value: legemiddelregisteret@fhi.no
+
+jurisdiction: urn:iso:std:iso:3166#NO "Norway"
+
+parameters:
+  path-assets: input/assets
+  apply-contact: true
+  apply-jurisdiction: true
+  generate-json: true
+  generate-xml: false
+  generate-turtle: false
+  no-narrative:
+    - MedicationAdministration/*
+    - MedicationRequest/*
+    - Medication/*
+    - Patient/*
+    - Encounter/*
+    - Condition/*
+    - Organization/*
+    - Practitioner/*
+    - Substance/*
+    - Bundle/*
+dependencies:
+  hl7.fhir.uv.extensions.r4: "5.2.0"
+  hl7.fhir.no.basis: "2.2.0"
+
+
+pages:
+  index.md:
+    title: Hjem
+  informasjonsmodell.md:
+    title: Informasjonsmodell
+  integrasjon.md:
+    title: Integrasjon
+    SignertKryptertBundle.md:
+      title: SignertKryptertBundle
+    protokoll.md:
+      title: Protokoll
+    eksempelkode_cs.md:
+        title: "C# eksempelkode"
+        generation: markdown
+    eksempelkode_ps1.md:
+        title: "Powershell eksempelkode"
+        generation: markdown
+  nedlastinger.md:
+    title: Nedlastinger
+  profiler.md:
+    title: "FHIR-profiler"
+    generation: markdown
+ 
+menu:
+  Hjem: index.html
+  Informasjonsmodell: informasjonsmodell.html
+  Integrasjon: integrasjon.html
+  FHIR-profiler: profiler.html
+  Nedlastinger: nedlastinger.html

--- a/.claude/skills/lmdi-fhir/scripts/sync_references.sh
+++ b/.claude/skills/lmdi-fhir/scripts/sync_references.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Vedlikeholdsscript — kun for bruk i kilderepoet (ikke i distribuert ZIP).
+# Synkroniserer FSH-kilder og sushi-config.yaml fra LMDI/ til references/
+# Idempotent — trygt å kjøre flere ganger.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
+
+SOURCE_FSH="$REPO_ROOT/LMDI/input/fsh"
+SOURCE_CONFIG="$REPO_ROOT/LMDI/sushi-config.yaml"
+TARGET_REF="$SKILL_DIR/references"
+TARGET_FSH="$TARGET_REF/fsh"
+
+# Sjekk at forventede kildebaner finnes
+for path in "$SOURCE_FSH" "$SOURCE_CONFIG" \
+            "$SOURCE_FSH/aliases.fsh" \
+            "$SOURCE_FSH/profiles" \
+            "$SOURCE_FSH/extensions" \
+            "$SOURCE_FSH/valuesets" \
+            "$SOURCE_FSH/namingsystems"; do
+    if [[ ! -e "$path" ]]; then
+        echo "FEIL: Forventet kildebane mangler: $path" >&2
+        exit 1
+    fi
+done
+
+# Opprett målmapper
+mkdir -p "$TARGET_FSH"
+
+# Kopier sushi-config.yaml
+cp "$SOURCE_CONFIG" "$TARGET_REF/sushi-config.yaml"
+echo "Kopiert sushi-config.yaml"
+
+# Kopier aliases.fsh
+cp "$SOURCE_FSH/aliases.fsh" "$TARGET_FSH/aliases.fsh"
+echo "Kopiert aliases.fsh"
+
+# Synkroniser undermapper (sletter innhold først, kopierer deretter fra kilde)
+for subdir in profiles extensions valuesets namingsystems; do
+    if [[ -d "$SOURCE_FSH/$subdir" ]]; then
+        rm -rf "$TARGET_FSH/$subdir"
+        mkdir -p "$TARGET_FSH/$subdir"
+        cp "$SOURCE_FSH/$subdir"/*.fsh "$TARGET_FSH/$subdir/"
+        echo "Synkronisert $subdir/"
+    fi
+done
+
+# Slett eventuelle undermapper i target som ikke finnes i source
+for target_subdir in "$TARGET_FSH"/*/; do
+    subdir_name="$(basename "$target_subdir")"
+    if [[ ! -d "$SOURCE_FSH/$subdir_name" ]]; then
+        rm -rf "$target_subdir"
+        echo "Slettet utdatert mappe: $subdir_name/"
+    fi
+done
+
+echo ""
+echo "Sync fullført. Snapshot oppdatert i: $TARGET_REF"

--- a/.claude/skills/lmdi-fhir/scripts/validate_skill.sh
+++ b/.claude/skills/lmdi-fhir/scripts/validate_skill.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Validerer at SKILL.md er konsistent med snapshoten i references/
+# Sjekker: filreferanser, ingen eksterne stier, mappingtabell-dekning, metadata-synk.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL_MD="$SKILL_DIR/SKILL.md"
+TARGET_FSH="$SKILL_DIR/references/fsh"
+TARGET_CONFIG="$SKILL_DIR/references/sushi-config.yaml"
+
+ERRORS=0
+
+error() {
+    echo "FEIL: $1" >&2
+    ERRORS=$((ERRORS + 1))
+}
+
+# --- 1. Sjekk at SKILL.md ikke bruker LMDI/input/fsh/ som kilde (unntak: redigeringsinstruksjonen) ---
+echo "=== Sjekker eksterne stier ==="
+# Filtrer bort linjen som forklarer at redigeringer gjøres i LMDI/input/fsh/
+ext_hits=$(grep -n 'LMDI/input/fsh/' "$SKILL_MD" | grep -v 'redigere\|rediger\|endring' || true)
+if [[ -n "$ext_hits" ]]; then
+    error "SKILL.md refererer til LMDI/input/fsh/ som kilde (ikke redigeringsinstruksjon):"
+    echo "$ext_hits" | head -5 >&2
+fi
+
+# --- 2. Sjekk at filreferanser i SKILL.md finnes i snapshoten ---
+echo "=== Sjekker filreferanser ==="
+# Hent konkrete .fsh-filreferanser (ignorer glob-mønstre med *)
+refs_file=$(mktemp)
+grep -oE 'references/fsh/[^ |`\)]+\.fsh' "$SKILL_MD" \
+    | grep -v '\*' \
+    | sort -u > "$refs_file"
+while read -r ref; do
+    full_path="$SKILL_DIR/$ref"
+    if [[ ! -f "$full_path" ]]; then
+        error "Filreferanse i SKILL.md peker til manglende fil: $ref"
+    fi
+done < "$refs_file"
+rm -f "$refs_file"
+
+# --- 3. Mappingtabell-dekning ---
+echo "=== Sjekker mappingtabell-dekning ==="
+
+# Bygg lookup: for hvert artefakt samle både FSH-navn og Id (hvis definert)
+# Sjekk at minst én av dem finnes i tabellen
+snapshot_pairs=$(mktemp)
+
+# Hent Profile/Extension/ValueSet-definisjoner med deres Id (hvis den finnes)
+for fsh_file in "$TARGET_FSH"/profiles/*.fsh "$TARGET_FSH"/extensions/*.fsh "$TARGET_FSH"/valuesets/*.fsh; do
+    [[ -f "$fsh_file" ]] || continue
+    grep -nE '^(Profile|Extension|ValueSet): ' "$fsh_file" 2>/dev/null | while IFS=: read -r line_num match; do
+        fsh_name=$(echo "$match" | sed 's/^\(Profile\|Extension\|ValueSet\): *//' | tr -d '\r' | sed 's/ *$//')
+        # Sjekk om det finnes en Id: innen de neste 5 linjene
+        fsh_id=$(sed -n "$((line_num+1)),$((line_num+5))p" "$fsh_file" \
+            | grep -E '^Id: ' | head -1 | sed 's/^Id: *//' | tr -d '\r' | sed 's/ *$//' || true)
+        if [[ -n "$fsh_id" ]]; then
+            echo "${fsh_name}|${fsh_id}"
+        else
+            echo "${fsh_name}|${fsh_name}"
+        fi
+    done
+done > "$snapshot_pairs"
+
+# Hent artefakter fra mappingtabellen (første kolonne, fjern suffiks)
+table_ids=$(mktemp)
+grep -E '^\|[^|]+\|.*references/fsh/' "$SKILL_MD" \
+    | sed 's/^| *//;s/ *(ext)//;s/ *(vs)//;s/ *(cs)//;s/ *|.*//' \
+    | tr -d '\r' \
+    | sort -u > "$table_ids"
+
+# Sjekk at hvert snapshot-artefakt har en rad (match på enten navn eller Id)
+while IFS='|' read -r fsh_name fsh_id; do
+    [[ -z "$fsh_name" ]] && continue
+    if ! grep -qx "$fsh_name" "$table_ids" && ! grep -qx "$fsh_id" "$table_ids"; then
+        error "Snapshot-artefakt '$fsh_name' (Id: $fsh_id) mangler rad i mappingtabellen"
+    fi
+done < "$snapshot_pairs"
+
+rm -f "$snapshot_pairs" "$table_ids"
+
+# --- 3b. Sjekk at hver mappingrad peker til riktig artefakt i riktig fil ---
+echo "=== Sjekker at tabellrader peker til riktig artefakt i riktig fil ==="
+table_rows=$(mktemp)
+grep -E '^\|[^|]+\|.*references/fsh/' "$SKILL_MD" | tr -d '\r' > "$table_rows"
+while IFS='|' read -r _ artifact_col file_col _rest; do
+    # Trim whitespace og fjern suffiks
+    artifact=$(echo "$artifact_col" | sed 's/^ *//;s/ *$//;s/ *(ext)$//;s/ *(vs)$//;s/ *(cs)$//')
+    fsh_file=$(echo "$file_col" | sed 's/^ *`//;s/`.*//;s/ *$//')
+    [[ -z "$artifact" || -z "$fsh_file" ]] && continue
+    full_path="$SKILL_DIR/$fsh_file"
+    [[ ! -f "$full_path" ]] && continue
+    # Sjekk at artefaktet finnes i filen (match på Id: eller Profile:/Extension:/ValueSet: navn, tolererer trailing whitespace)
+    if ! grep -qE "(^(Profile|Extension|ValueSet): *${artifact} *$|^Id: *${artifact} *$)" "$full_path" 2>/dev/null; then
+        error "Tabellrad '$artifact' peker til '$fsh_file', men artefaktet finnes ikke i den filen"
+    fi
+done < "$table_rows"
+rm -f "$table_rows"
+
+# --- 4. Metadata-synk ---
+echo "=== Sjekker metadata-synk ==="
+if [[ -f "$TARGET_CONFIG" ]]; then
+    config_version=$(grep -E '^version:' "$TARGET_CONFIG" | sed 's/version: *//' | tr -d '\r')
+    skill_version=$(grep 'Versjon: `' "$SKILL_MD" | sed 's/.*Versjon: `//;s/`.*//' | tr -d '\r')
+    if [[ -n "$config_version" && -n "$skill_version" && "$config_version" != "$skill_version" ]]; then
+        error "Versjon mismatch: sushi-config.yaml=$config_version, SKILL.md=$skill_version"
+    fi
+
+    config_date=$(grep -E '^date:' "$TARGET_CONFIG" | sed 's/date: *//' | tr -d '\r')
+    skill_date=$(grep 'Dato: `' "$SKILL_MD" | sed 's/.*Dato: `//;s/`.*//' | tr -d '\r')
+    if [[ -n "$config_date" && -n "$skill_date" && "$config_date" != "$skill_date" ]]; then
+        error "Dato mismatch: sushi-config.yaml=$config_date, SKILL.md=$skill_date"
+    fi
+
+    config_status=$(grep -E '^status:' "$TARGET_CONFIG" | sed 's/status: *//' | tr -d '\r')
+    skill_status=$(grep 'Status: `' "$SKILL_MD" | sed 's/.*Status: `//;s/`.*//' | tr -d '\r')
+    if [[ -n "$config_status" && -n "$skill_status" && "$config_status" != "$skill_status" ]]; then
+        error "Status mismatch: sushi-config.yaml=$config_status, SKILL.md=$skill_status"
+    fi
+else
+    error "references/sushi-config.yaml finnes ikke — kjør sync_references.sh først"
+fi
+
+# --- Resultat ---
+echo ""
+if [[ $ERRORS -gt 0 ]]; then
+    echo "Validering FEILET med $ERRORS feil."
+    exit 1
+else
+    echo "Validering OK — ingen feil funnet."
+    exit 0
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ cp -r ./node_modules/hl7.fhir.no.basis/* ~/.fhir/packages/hl7.fhir.no.basis#2.2.
 2. Run `sushi .` to compile FSH to FHIR resources
 3. For full documentation generation, run IG Publisher
 4. Generated content appears in `LMDI/output/`
+5. Etter endringer i FSH-filer: kjør `bash .claude/skills/lmdi-fhir/scripts/sync_references.sh` for å oppdatere skill-snapshoten, og `bash .claude/skills/lmdi-fhir/scripts/validate_skill.sh` for å verifisere konsistens
 
 The project follows Norwegian healthcare data standards and integrates with FEST (Norwegian drug database) identifiers.
 


### PR DESCRIPTION
## Summary
- Gjør lmdi-fhir skillen self-contained med FSH-snapshot under `references/`
- Legger til `sync_references.sh` og `validate_skill.sh` for vedlikehold av snapshoten
- Oppdaterer SKILL.md med mappingtabell og ny arbeidsmåte basert på lokal snapshot
- Oppdaterer CLAUDE.md med instruksjon for snapshot-vedlikehold etter FSH-endringer

## Test plan
- [x] `validate_skill.sh` kjører uten feil
- [x] FSH-snapshot er identisk med kilde-FSH-filer
- [x] Metadata i SKILL.md matcher sushi-config.yaml