### PR TITLE
Rename FestVirkestoff-slice og legg til display-beskrivelse for merkevare

### DIFF
--- a/LMDI/input/fsh/profiles/lmdi-Medication.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-Medication.fsh
@@ -73,6 +73,7 @@ Description: "Beskrivelse av legemiddel."
 
 * code.coding[LokaltLegemiddel].display 1..1
 * code.coding[LokaltLegemiddel].display ^short = "Beskrivelse (f.eks. varenavn) for legemiddel fra lokal legemiddelkatalog/legemiddelregister"
+* code.coding[FestLegemiddelMerkevare].display ^short = "Varenavn fra FEST"
 
 * extension ^slicing.discriminator.type = #value
 * extension ^slicing.discriminator.path = "url"


### PR DESCRIPTION
## Summary
- Endrer slicenavn fra `FestVirkestoff` til `FestLegemiddelVirkestoff` for konsistens med øvrige FEST-slices
- Legger til `^short = "Varenavn fra FEST"` på `code.coding[FestLegemiddelMerkevare].display` (fixes #68)

## Test plan
- [ ] Kjør `sushi .` og verifiser at FSH kompilerer uten feil
- [ ] Sjekk at generert StructureDefinition inneholder ny short-beskrivelse for FestLegemiddelMerkevare.display
- [ ] Verifiser at alle referanser til FestLegemiddelVirkestoff er oppdatert korrekt