### PR TITLE
Mengde ingrediens på Medication.ingredient

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,17 +103,17 @@ cp -r ./node_modules/hl7.fhir.no.basis/* ~/.fhir/packages/hl7.fhir.no.basis#2.2.
 2. Run `sushi .` to compile FSH to FHIR resources
 3. For full documentation generation, run IG Publisher
 4. Generated content appears in `LMDI/output/`
-5. Etter endringer i FSH-filer: oppdater lmdi-fhir-skillen etter prosedyren i `.claude/skills/lmdi-fhir/UPDATE.md`
+5. Etter endringer i FSH-filer: oppdater lmdi-fhir-skillen etter prosedyren i `C:\dev\Fhi.Lmr.AI\skills\lmdi-fhir\UPDATE.md`
 
 ## Claude Skills
 
-`.claude/skills/lmdi-fhir/` er en symlink til `Fhi.Legemiddelregisteret.wiki`-repoet (`AgentSkills/lmdi-fhir/`). Skill-filene (SKILL.md, UPDATE.md, references/) versjonsstyres **ikke** i dette repoet.
+`lmdi-fhir`-skillen ligger i **`C:\dev\Fhi.Lmr.AI\skills\lmdi-fhir`** og versjonsstyres i repoet `Fhi.Lmr.AI` (Azure DevOps: `fhi/Fhi.Legemiddelregisteret/_git/Fhi.Lmr.AI`), ikke i dette repoet. Den distribueres som skill i `lmr`-pluginen via marketplace `fhi-lmr`.
 
 **Viktig ved arbeid med skill-filer:**
 - Sjekk at skill-filene er oppdatert med siste FSH-endringer før bruk (se proveniens-tabellen i `UPDATE.md`)
-- Oppdatering av skillen gjøres etter prosedyren i `.claude/skills/lmdi-fhir/UPDATE.md`
-- Endringer i skill-filer må committes og pushes i wiki-repoet (`Fhi.Legemiddelregisteret.wiki`)
-- `.claude/skills/` er lagt til i `.gitignore` og trackes ikke her
+- Oppdatering av skillen gjøres etter prosedyren i `C:\dev\Fhi.Lmr.AI\skills\lmdi-fhir\UPDATE.md`
+- Endringer i skill-filer må committes og pushes i `Fhi.Lmr.AI`
+- `.claude/skills/` er lagt til i `.gitignore` og trackes ikke her. Symlinken `.claude/skills/lmdi-fhir` peker fortsatt på den utgåtte plasseringen i `Fhi.Legemiddelregisteret.wiki` og virker ikke — bruk stien over.
 
 The project follows Norwegian healthcare data standards and integrates with FEST (Norwegian drug database) identifiers.
 

--- a/LMDI/input/fsh/aliases.fsh
+++ b/LMDI/input/fsh/aliases.fsh
@@ -10,6 +10,9 @@ Alias: $organization-type = http://terminology.hl7.org/CodeSystem/organization-t
 // ATC alias
 Alias: $ATC = http://www.whocc.no/atc
 
+// Kodeverk for kodet mengde ingrediens (R5/R6)
+Alias: $IngrediensStyrkeKoder = http://hl7.org/fhir/CodeSystem/medication-ingredientstrength
+
 // Volven alias
 Alias: $organisatoriskBetegnelse = urn:oid:2.16.578.1.12.4.1.1.8624
 

--- a/LMDI/input/fsh/extensions/lmdi-ext-ingredient-strength.fsh
+++ b/LMDI/input/fsh/extensions/lmdi-ext-ingredient-strength.fsh
@@ -1,0 +1,28 @@
+Extension: IngrediensStyrke
+Id: lmdi-ingredient-strength
+Title: "Mengde ingrediens"
+Description: "Mengde ingrediens i det rekvirerte/administrerte legemidlet, angitt som Quantity eller som kode. Angir enten mengden virkestoff av ingrediensen i det rekvirerte/administrerte legemidlet (f.eks. 100 mg) eller hvilket volum av ingrediensen som er brukt for å produsere det rekvirerte/administrerte legemidlet (f.eks. 10 mL). Når volum benyttes skal ingredient.item angi «utgangslegemidlet» som ble brukt for å produsere det rekvirerte/administrerte legemidlet på en slik måte at «utgangslegemidlets» styrke kan utledes. Dette er nødvendig for å kunne beregne mengde virkestoff og styrke av ingrediensen i det rekvirerte/administrerte legemidlet."
+// Speiler Medication.ingredient.strength[x] i FHIR R5/R6, som tillater Ratio, CodeableConcept og
+// Quantity. I R4 er strength en ren Ratio, så de to øvrige variantene må uttrykkes som extension.
+// R4-invarianten rat-1 tillater en Ratio uten teller og nevner når den har en extension.
+* ^context.type = #element
+* ^context.expression = "Medication.ingredient.strength"
+* ^status = #draft
+* ^date = "2026-08-18"
+* ^publisher = "Folkehelseinstituttet"
+* ^title.extension[+].url = "http://hl7.org/fhir/StructureDefinition/translation"
+* ^title.extension[=].extension[+].url = "lang"
+* ^title.extension[=].extension[=].valueCode = #en
+* ^title.extension[=].extension[+].url = "content"
+* ^title.extension[=].extension[=].valueString = "Amount of ingredient"
+* ^description.extension[+].url = "http://hl7.org/fhir/StructureDefinition/translation"
+* ^description.extension[=].extension[+].url = "lang"
+* ^description.extension[=].extension[=].valueCode = #en
+* ^description.extension[=].extension[+].url = "content"
+* ^description.extension[=].extension[=].valueString = "Amount of the ingredient in the requested/administered medication, expressed as a Quantity or as a code. Specifies either the amount of active ingredient in the requested/administered medication (e.g. 100 mg), or the volume of the ingredient used to produce the requested/administered medication (e.g. 10 mL). When volume is used, ingredient.item shall specify the “starting medication” used to produce the requested/administered medication in such a way that the strength of the “starting medication” can be derived. This is necessary to calculate the amount of active ingredient and the strength of the ingredient in the requested/administered medication."
+* value[x] only CodeableConcept or Quantity
+// Bindingen settes på value[x], ikke på valueCodeableConcept: med to tillatte typer finnes det
+// ikke noe eget valueCodeableConcept-element. Kodeverket har kun kodene qs og trace.
+* value[x] ^binding.strength = #preferred
+* value[x] ^binding.description = "Medication Ingredient Strength Codes"
+* value[x] ^binding.valueSet = "http://hl7.org/fhir/ValueSet/medication-ingredientstrength"

--- a/LMDI/input/fsh/profiles/lmdi-Medication.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-Medication.fsh
@@ -324,6 +324,34 @@ Description: "Beskrivelse av legemiddel."
 * ingredient.itemReference only Reference($LMDISubstance or $LMDIMedication)
 * ingredient.itemCodeableConcept from LegemiddelKoder (preferred)
 
+* ingredient.strength ^short = "Styrken av ingrediensen i det rekvirerte/administrerte legemidlet."
+* ingredient.strength ^definition = "Styrken av ingrediensen i det rekvirerte/administrerte legemidlet."
+* ingredient.strength ^short.extension[+].url = "http://hl7.org/fhir/StructureDefinition/translation"
+* ingredient.strength ^short.extension[=].extension[+].url = "lang"
+* ingredient.strength ^short.extension[=].extension[=].valueCode = #en
+* ingredient.strength ^short.extension[=].extension[+].url = "content"
+* ingredient.strength ^short.extension[=].extension[=].valueString = "The strength of the ingredient in the requested/administered medication."
+* ingredient.strength ^definition.extension[+].url = "http://hl7.org/fhir/StructureDefinition/translation"
+* ingredient.strength ^definition.extension[=].extension[+].url = "lang"
+* ingredient.strength ^definition.extension[=].extension[=].valueCode = #en
+* ingredient.strength ^definition.extension[=].extension[+].url = "content"
+* ingredient.strength ^definition.extension[=].extension[=].valueString = "The strength of the ingredient in the requested/administered medication."
+
+// Mengde uttrykkes som extension fordi strength i R4 er en ren Ratio. Se lmdi-ingredient-strength.
+* ingredient.strength.extension contains IngrediensStyrke named mengde 0..1
+* ingredient.strength.extension[mengde] ^short = "Mengde ingrediens i det rekvirerte/administrerte legemidlet."
+* ingredient.strength.extension[mengde] ^definition = "Mengde ingrediens i det rekvirerte/administrerte legemidlet, angitt som volum eller mengde virkestoff (Quantity), eller som kode (qs, trace). Brukes i stedet for teller og nevner i strength."
+* ingredient.strength.extension[mengde] ^short.extension[+].url = "http://hl7.org/fhir/StructureDefinition/translation"
+* ingredient.strength.extension[mengde] ^short.extension[=].extension[+].url = "lang"
+* ingredient.strength.extension[mengde] ^short.extension[=].extension[=].valueCode = #en
+* ingredient.strength.extension[mengde] ^short.extension[=].extension[+].url = "content"
+* ingredient.strength.extension[mengde] ^short.extension[=].extension[=].valueString = "Amount of the ingredient in the requested/administered medication."
+* ingredient.strength.extension[mengde] ^definition.extension[+].url = "http://hl7.org/fhir/StructureDefinition/translation"
+* ingredient.strength.extension[mengde] ^definition.extension[=].extension[+].url = "lang"
+* ingredient.strength.extension[mengde] ^definition.extension[=].extension[=].valueCode = #en
+* ingredient.strength.extension[mengde] ^definition.extension[=].extension[+].url = "content"
+* ingredient.strength.extension[mengde] ^definition.extension[=].extension[=].valueString = "Amount of the ingredient in the requested/administered medication, expressed as a volume or amount of active ingredient (Quantity), or as a code (qs, trace). Used instead of numerator and denominator in strength."
+
 
 // EKSEMPLER
 Instance: Legemiddel-FestLegemiddelVirkestoff
@@ -486,6 +514,49 @@ Description: "Eksempel på lokalt katalogisert cellegift (Cisplatin)"
 * amount.numerator.code = #mg
 * amount.denominator.value = 1
 * amount.denominator.unit = "pose"
+
+Instance: Legemiddel-MorfinKonsentrat
+InstanceOf: Legemiddel
+Description: "Eksempel på morfinkonsentrat identifisert med FEST legemiddelmerkevare-id. Brukes som utgangslegemiddel i smerteblandingen, slik at styrken i blandingen kan utledes fra FEST."
+* extension[classification].valueCodeableConcept = $ATC#N02AA01 "Morfin"
+* code.coding[FestLegemiddelMerkevare].system = "http://dmp.no/fhir/NamingSystem/festLegemiddelMerkevare"
+* code.coding[FestLegemiddelMerkevare].code = #ID_1767DDFA-C248-4814-8EE8-A0C6D09E11BF
+* code.coding[FestLegemiddelMerkevare].display = "Morfin NAF inj, oppl 40 mg/ml"
+
+Instance: Legemiddel-Smerteblanding
+InstanceOf: Legemiddel
+Description: "Eksempel på lokalt tilberedt smerteblanding på 100 mL med morfin 5 mg/ml og midazolam 1 mg/ml. Viser de tre måtene å angi en ingrediens på, og bruk av mengde (mL) i tillegg til styrke."
+* code.coding[LokaltLegemiddel].system = "http://fhi.no/fhir/NamingSystem/lokaltLegemiddel"
+* code.coding[LokaltLegemiddel].code = #smerteblanding-morfin-midazolam
+* code.coding[LokaltLegemiddel].display = "Smerteblanding morfin 5 mg/ml og midazolam 1 mg/ml"
+// Totalvolum for blandingen. Nødvendig for å kunne utlede styrken til ingredienser som er
+// angitt med volum i stedet for styrke.
+* amount.numerator.value = 100
+* amount.numerator.unit = "milliliter"
+* amount.numerator.system = "http://unitsofmeasure.org"
+* amount.numerator.code = #mL
+* amount.denominator.value = 1
+* amount.denominator.unit = "pose"
+// Ingrediens angitt med FEST-id (itemCodeableConcept) og styrke i blandingen som Ratio
+* ingredient[0].itemCodeableConcept.coding.system = "http://dmp.no/fhir/NamingSystem/fest-varenummer"
+* ingredient[0].itemCodeableConcept.coding.code = #156660
+* ingredient[0].itemCodeableConcept.coding.display = "Midazolam Accordpharma inj/inf, oppl 1 mg/ml"
+* ingredient[0].strength.numerator.value = 1
+* ingredient[0].strength.numerator.system = "http://unitsofmeasure.org"
+* ingredient[0].strength.numerator.code = #mg
+* ingredient[0].strength.denominator.value = 1
+* ingredient[0].strength.denominator.system = "http://unitsofmeasure.org"
+* ingredient[0].strength.denominator.code = #mL
+// Ingrediens angitt som referanse til Legemiddel (utgangslegemidlet), med mengde som volum.
+// 12,5 mL x 40 mg/ml = 500 mg morfin i 100 mL, altså 5 mg/ml i blandingen.
+* ingredient[1].itemReference = Reference(Legemiddel-MorfinKonsentrat)
+* ingredient[1].strength.extension[mengde].valueQuantity.value = 12.5
+* ingredient[1].strength.extension[mengde].valueQuantity.unit = "milliliter"
+* ingredient[1].strength.extension[mengde].valueQuantity.system = "http://unitsofmeasure.org"
+* ingredient[1].strength.extension[mengde].valueQuantity.code = #mL
+// Ingrediens angitt som referanse til Virkestoff, med kodet mengde. qs = fylles opp til 100 mL.
+* ingredient[2].itemReference = Reference(Virkestoff-Natriumklorid)
+* ingredient[2].strength.extension[mengde].valueCodeableConcept = $IngrediensStyrkeKoder#qs "QS"
 
 // Invarianter
 Invariant: lmdi-medication-code-or-ingredient

--- a/LMDI/input/fsh/profiles/lmdi-Substance.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-Substance.fsh
@@ -33,3 +33,13 @@ Description: "Eksempel på virkestoff - Oksykodon"
 * category.coding.system = "http://terminology.hl7.org/CodeSystem/substance-category"
 * category.coding.code = #drug
 * category.coding.display = "Drug or Medicament"
+
+Instance: Virkestoff-Natriumklorid
+InstanceOf: Virkestoff
+Description: "Eksempel på virkestoff - Natriumklorid"
+* code.coding.system = "http://snomed.info/sct"
+* code.coding.code = #387390002
+* code.coding.display = "Sodium chloride (substance)"
+* category.coding.system = "http://terminology.hl7.org/CodeSystem/substance-category"
+* category.coding.code = #drug
+* category.coding.display = "Drug or Medicament"

--- a/LMDI/input/ignoreWarnings.txt
+++ b/LMDI/input/ignoreWarnings.txt
@@ -13,3 +13,7 @@ Value set 'urn:iso:std:iso:3166' .* not found
 Value set 'urn:oid:2.16.578.1.12.4.1.1.9060' .* not found
 Value set 'urn:oid:2.16.578.1.12.4.1.1.7704' .* not found
 Value set 'urn:oid:2.16.578.1.12.4.1.1.7426' .* not found
+# Kodeverket for kodet mengde ingrediens (qs, trace) er definert i R5 og finnes ikke i R4.
+# Bindingen på lmdi-ingredient-strength er preferred og dokumenterer hvilke koder som gjelder.
+A definition could not be found for Canonical URL 'http://hl7.org/fhir/ValueSet/medication-ingredientstrength'
+ValueSet 'http://hl7.org/fhir/ValueSet/medication-ingredientstrength' not found

--- a/LMDI/input/pagecontent/en-profiler.md
+++ b/LMDI/input/pagecontent/en-profiler.md
@@ -22,6 +22,7 @@ The LMDI implementation guide defines the following FHIR profiles and extensions
 | Extension | Used on | Description |
 |-----------|---------|-------------|
 | [DelAvBehandlingsregime](StructureDefinition-lmdi-del-av-behandlingsregime.html) | [Legemiddelrekvirering](StructureDefinition-lmdi-medicationrequest.html) | The name of the regimen, treatment protocol, or course the medication is given as part of. Particularly relevant in chemotherapy. |
+| [IngrediensStyrke](StructureDefinition-lmdi-ingredient-strength.html) | [Legemiddel](StructureDefinition-lmdi-medication.html) | Amount of the ingredient in the requested/administered medication, expressed as a volume or amount of active ingredient, or as a code. Used on Legemiddel.ingredient.strength when an amount is to be expressed instead of a strength. |
 | [KliniskStudie](StructureDefinition-lmdi-klinisk-studie.html) | [Legemiddelrekvirering](StructureDefinition-lmdi-medicationrequest.html) | Indicates whether the medication is given as part of a clinical trial. |
 | [LegemiddelClassification](StructureDefinition-legemiddel-classification.html) | [Legemiddel](StructureDefinition-lmdi-medication.html) | Classification of medications, primarily using ATC codes (Anatomical Therapeutic Chemical classification). |
 | [NprEpisodeIdentifier](StructureDefinition-npr-episode-identifier.html) | [Episode](StructureDefinition-lmdi-encounter.html) | Unique identifier for the episode as used in reporting to the Norwegian Patient Registry (NPR). Supports both string-based and UUID-based representations. |

--- a/LMDI/input/pagecontent/profiler.md
+++ b/LMDI/input/pagecontent/profiler.md
@@ -22,6 +22,7 @@ Implementasjonsguiden definerer følgende FHIR-profiler og extensions.
 | Extension | Brukes på | Beskrivelse |
 |-----------|----------|-------------|
 | [DelAvBehandlingsregime](StructureDefinition-lmdi-del-av-behandlingsregime.html) | [Legemiddelrekvirering](StructureDefinition-lmdi-medicationrequest.html) | Navnet på kuren, behandlingsregimet eller protokollen legemidlet gis som en del av. Spesielt relevant ved kjemoterapi. |
+| [IngrediensStyrke](StructureDefinition-lmdi-ingredient-strength.html) | [Legemiddel](StructureDefinition-lmdi-medication.html) | Mengde ingrediens i det rekvirerte/administrerte legemidlet, angitt som volum eller mengde virkestoff, eller som kode. Brukes på Legemiddel.ingredient.strength når mengde skal uttrykkes i stedet for styrke. |
 | [KliniskStudie](StructureDefinition-lmdi-klinisk-studie.html) | [Legemiddelrekvirering](StructureDefinition-lmdi-medicationrequest.html) | Angir om legemidlet gis som en del av en klinisk studie. |
 | [LegemiddelClassification](StructureDefinition-legemiddel-classification.html) | [Legemiddel](StructureDefinition-lmdi-medication.html) | Klassifisering av legemidler, primært med ATC-koder (Anatomisk Terapeutisk Kjemisk legemiddelregister). |
 | [NprEpisodeIdentifier](StructureDefinition-npr-episode-identifier.html) | [Episode](StructureDefinition-lmdi-encounter.html) | Unik identifikator for episoden, som brukt i rapportering til Norsk pasientregister (NPR). Støtter både string-basert og UUID-basert representasjon. |


### PR DESCRIPTION
Lukker #101.

## Bakgrunn

`Medication.ingredient.strength` kan i dag bare uttrykke **styrke** som en Ratio. For sammensatte legemidler trenger vi å uttrykke **mengde** — «denne blandingen inneholder 12,5 mL av konsentrat X» — og «q.s.» for ingredienser som saltvann. Å presse dette inn i en Ratio med nevner er semantisk feil.

Issue-teksten foreslo opprinnelig en extension `lmdi-ingredient-amount` på `Medication.ingredient`. I kommentarene styrte Kari mot R6-løsningen i stedet, der `strength[x]` har tre varianter: `strengthRatio`, `strengthCodeableConcept` og `strengthQuantity`. Denne PR-en følger Karis forslag, som flytter extensionen ett nivå dypere til `Medication.ingredient.strength`.

## Hvorfor extension og ikke slicing

FHIR R4 har ikke `strength[x]` — `Medication.ingredient.strength` er en ren `Ratio 0..1`, og valgtyper kan ikke slices. De to nye variantene må derfor uttrykkes som extension. R4-invarianten `rat-1` er skrevet nettopp for dette:

> Numerator and denominator SHALL both be present, or both are absent. If both are absent, there SHALL be some extension present

En `strength` med bare extension, uten teller og nevner, er altså gyldig R4.

## Endringer

**Ny extension** `lmdi-ingredient-strength` («Mengde ingrediens»), context `Medication.ingredient.strength`, `value[x]` = `CodeableConcept | Quantity`, preferred binding til `http://hl7.org/fhir/ValueSet/medication-ingredientstrength` (kodene `qs` og `trace`). Norsk og engelsk tekst hentet ordrett fra Karis kommentar i issuet.

**Legemiddel-profilen** har fått beskrivelse på `ingredient.strength` (styrken av ingrediensen) og extensionen sliced inn som `mengde 0..1`. Kardinaliteten på `strength` er uendret og extensionen er valgfri, så endringen er rent additiv.

**Nytt eksempel** `Legemiddel-Smerteblanding` — 100 mL med morfin 5 mg/ml og midazolam 1 mg/ml, som viser alle tre måtene å angi en ingrediens på:

| Ingrediens | Angitt som | Uttrykt med |
|---|---|---|
| Midazolam | `itemCodeableConcept` (FEST-varenummer) | `strength` Ratio 1 mg/1 mL |
| Morfin NAF 40 mg/ml | `itemReference` → Legemiddel | `strength.extension[mengde].valueQuantity` = 12,5 mL |
| Natriumklorid | `itemReference` → Virkestoff | `strength.extension[mengde].valueCodeableConcept` = `qs` |

`Medication.amount` = 100 mL/pose gjør utledningen mulig: 12,5 mL × 40 mg/ml = 500 mg i 100 mL = 5 mg/ml. Uten totalvolum kan ikke morfinkonsentrasjonen regnes ut, og eksempelet ville lært regelen samtidig som det brøt den.

Støtteinstanser: `Legemiddel-MorfinKonsentrat` og `Virkestoff-Natriumklorid`.

## Verifisering

- `sushi .` gir 0 errors
- Full IG-bygg kjørt. Generert JSON bekrefter `rat-1`-formen: ingrediens 2 og 3 har `strength` med kun `extension`
- Ingen strukturelle valideringsfeil på eksempelet. `Quantity`-varianten gir ingen meldinger overhodet
- Engelsk speiling komplett — `sjekk-oversettelser.py` gir `0 mangler, 0 MS-tooltips anvendes ikke`

## Kjent QA-støy

R4-verktøy kan ikke slå opp R5-kanonikalen, så bygget får 3 nye feil (2 på extensionen, 1 på `qs`-koden i eksempelet). De er akseptert etter avklaring. Bindingen er `preferred`, så de blokkerer ikke validering av instanser. Warning-variantene er lagt i `ignoreWarnings.txt`.

HL7 har en offisiell cross-version-extension for nøyaktig dette i `hl7.fhir.uv.xver-r5.r4#0.1.0`, med samme to typer. Vi valgte egen extension for å slippe en avhengighet til en pre-release-pakke med versjonspinnet ValueSet, og for å ha kontroll på norsk/engelsk tekst. Verdt å vite hvis IG-en senere skal migreres til R5/R6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

