### PR TITLE
Fjern binding på mengde-extension og rett saltvann-eksempelet

### DIFF
--- a/LMDI/input/fsh/extensions/lmdi-ext-ingredient-strength.fsh
+++ b/LMDI/input/fsh/extensions/lmdi-ext-ingredient-strength.fsh
@@ -1,7 +1,13 @@
 Extension: IngrediensStyrke
 Id: lmdi-ingredient-strength
 Title: "Mengde ingrediens"
-Description: "Mengde ingrediens i det rekvirerte/administrerte legemidlet, angitt som Quantity eller som kode. Angir enten mengden virkestoff av ingrediensen i det rekvirerte/administrerte legemidlet (f.eks. 100 mg) eller hvilket volum av ingrediensen som er brukt for å produsere det rekvirerte/administrerte legemidlet (f.eks. 10 mL). Når volum benyttes skal ingredient.item angi «utgangslegemidlet» som ble brukt for å produsere det rekvirerte/administrerte legemidlet på en slik måte at «utgangslegemidlets» styrke kan utledes. Dette er nødvendig for å kunne beregne mengde virkestoff og styrke av ingrediensen i det rekvirerte/administrerte legemidlet."
+Description: """
+Mengde ingrediens i det rekvirerte/administrerte legemidlet, angitt som Quantity eller som CodeableConcept.
+
+Ved Quantity: Enten mengden virkestoff av ingrediensen i det rekvirerte/administrerte legemidlet (f.eks. 100 mg) eller hvilket volum av ingrediensen som er brukt for å produsere det rekvirerte/administrerte legemidlet (f.eks. 10 mL). Når volum benyttes skal ingredient.item angi «utgangslegemidlet» som ble brukt for å produsere det rekvirerte/administrerte legemidlet på en slik måte at «utgangslegemidlets» styrke kan utledes. Dette er nødvendig for å kunne beregne mengde virkestoff og styrke av ingrediensen i det rekvirerte/administrerte legemidlet.
+
+Ved CodeableConcept: Kodet verdi som angir mengden ingrediens, f.eks. qs eller trace. F.eks. fra kodeverk "Angi at bestanddel i legemiddelblanding ikke har eksakt mengde" (OID 7502) eller "Medication-ingredientstrength" http://hl7.org/fhir/CodeSystem/medication-ingredientstrength
+"""
 // Speiler Medication.ingredient.strength[x] i FHIR R5/R6, som tillater Ratio, CodeableConcept og
 // Quantity. I R4 er strength en ren Ratio, så de to øvrige variantene må uttrykkes som extension.
 // R4-invarianten rat-1 tillater en Ratio uten teller og nevner når den har en extension.
@@ -19,10 +25,20 @@ Description: "Mengde ingrediens i det rekvirerte/administrerte legemidlet, angit
 * ^description.extension[=].extension[+].url = "lang"
 * ^description.extension[=].extension[=].valueCode = #en
 * ^description.extension[=].extension[+].url = "content"
-* ^description.extension[=].extension[=].valueString = "Amount of the ingredient in the requested/administered medication, expressed as a Quantity or as a code. Specifies either the amount of active ingredient in the requested/administered medication (e.g. 100 mg), or the volume of the ingredient used to produce the requested/administered medication (e.g. 10 mL). When volume is used, ingredient.item shall specify the “starting medication” used to produce the requested/administered medication in such a way that the strength of the “starting medication” can be derived. This is necessary to calculate the amount of active ingredient and the strength of the ingredient in the requested/administered medication."
+* ^description.extension[=].extension[=].valueString = """
+Amount of the ingredient in the requested/administered medication, expressed as a Quantity or as a CodeableConcept.
+
+For Quantity: Either the amount of active ingredient in the requested/administered medication (e.g. 100 mg), or the volume of the ingredient used to produce the requested/administered medication (e.g. 10 mL). When volume is used, ingredient.item shall specify the “starting medication” used to produce the requested/administered medication in such a way that the strength of the “starting medication” can be derived. This is necessary to calculate the amount of active ingredient and the strength of the ingredient in the requested/administered medication.
+
+For CodeableConcept: A coded value specifying the amount of the ingredient, e.g. qs or trace. For example from the code system "Angi at bestanddel i legemiddelblanding ikke har eksakt mengde" (OID 7502) or "Medication-ingredientstrength" http://hl7.org/fhir/CodeSystem/medication-ingredientstrength
+"""
 * value[x] only CodeableConcept or Quantity
-// Bindingen settes på value[x], ikke på valueCodeableConcept: med to tillatte typer finnes det
-// ikke noe eget valueCodeableConcept-element. Kodeverket har kun kodene qs og trace.
-* value[x] ^binding.strength = #preferred
-* value[x] ^binding.description = "Medication Ingredient Strength Codes"
-* value[x] ^binding.valueSet = "http://hl7.org/fhir/ValueSet/medication-ingredientstrength"
+// Kodeverk anbefales i comment framfor binding: value[x] har to tillatte typer, så det finnes
+// ikke noe eget valueCodeableConcept-element å binde. En binding på value[x] ville dessuten ha
+// gjeldt Quantity-grenen, der den styrer enhetskoden.
+* value[x] ^comment = "Ved kodet mengde anbefales det norske kodeverket med OID 2.16.578.1.12.4.1.1.7502, eller kodeverket medication-ingredientstrength fra FHIR R5 (kodene qs og trace)."
+* value[x] ^comment.extension[+].url = "http://hl7.org/fhir/StructureDefinition/translation"
+* value[x] ^comment.extension[=].extension[+].url = "lang"
+* value[x] ^comment.extension[=].extension[=].valueCode = #en
+* value[x] ^comment.extension[=].extension[+].url = "content"
+* value[x] ^comment.extension[=].extension[=].valueString = "For a coded amount, the recommended code systems are the Norwegian code system with OID 2.16.578.1.12.4.1.1.7502, or the FHIR R5 code system medication-ingredientstrength (codes qs and trace)."

--- a/LMDI/input/fsh/profiles/lmdi-Medication.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-Medication.fsh
@@ -523,9 +523,17 @@ Description: "Eksempel på morfinkonsentrat identifisert med FEST legemiddelmerk
 * code.coding[FestLegemiddelMerkevare].code = #ID_1767DDFA-C248-4814-8EE8-A0C6D09E11BF
 * code.coding[FestLegemiddelMerkevare].display = "Morfin NAF inj, oppl 40 mg/ml"
 
+Instance: Legemiddel-NatriumkloridBBraun
+InstanceOf: Legemiddel
+Description: "Eksempel på sterilt saltvann identifisert med FEST legemiddelmerkevare-id. Brukes til å fylle opp smerteblandingen til totalvolumet."
+* extension[classification].valueCodeableConcept = $ATC#V07AB "Oppløsnings- og fortynningsvæsker, inkl. skyllemidler"
+* code.coding[FestLegemiddelMerkevare].system = "http://dmp.no/fhir/NamingSystem/festLegemiddelMerkevare"
+* code.coding[FestLegemiddelMerkevare].code = #ID_42240226-8225-468C-AB0A-9FD27AA67D44
+* code.coding[FestLegemiddelMerkevare].display = "Natriumklorid B. Braun oppl væske til parenteral bruk 9 mg/ml"
+
 Instance: Legemiddel-Smerteblanding
 InstanceOf: Legemiddel
-Description: "Eksempel på lokalt tilberedt smerteblanding på 100 mL med morfin 5 mg/ml og midazolam 1 mg/ml. Viser de tre måtene å angi en ingrediens på, og bruk av mengde (mL) i tillegg til styrke."
+Description: "Eksempel på lokalt tilberedt smerteblanding på 100 mL med morfin 5 mg/ml og midazolam 1 mg/ml. Viser de tre måtene å angi strength på: Ratio, Quantity (mL) og CodeableConcept (qs)."
 * code.coding[LokaltLegemiddel].system = "http://fhi.no/fhir/NamingSystem/lokaltLegemiddel"
 * code.coding[LokaltLegemiddel].code = #smerteblanding-morfin-midazolam
 * code.coding[LokaltLegemiddel].display = "Smerteblanding morfin 5 mg/ml og midazolam 1 mg/ml"
@@ -556,8 +564,8 @@ Description: "Eksempel på lokalt tilberedt smerteblanding på 100 mL med morfin
 * ingredient[1].strength.extension[mengde].valueQuantity.unit = "milliliter"
 * ingredient[1].strength.extension[mengde].valueQuantity.system = "http://unitsofmeasure.org"
 * ingredient[1].strength.extension[mengde].valueQuantity.code = #mL
-// Ingrediens angitt som referanse til Virkestoff, med kodet mengde. qs = fylles opp til 100 mL.
-* ingredient[2].itemReference = Reference(Virkestoff-Natriumklorid)
+// Ingrediens angitt som referanse til Legemiddel, med kodet mengde. qs = fylles opp til 100 mL.
+* ingredient[2].itemReference = Reference(Legemiddel-NatriumkloridBBraun)
 * ingredient[2].strength.extension[mengde].valueCodeableConcept = $IngrediensStyrkeKoder#qs "QS"
 
 // Invarianter

--- a/LMDI/input/fsh/profiles/lmdi-Substance.fsh
+++ b/LMDI/input/fsh/profiles/lmdi-Substance.fsh
@@ -33,13 +33,3 @@ Description: "Eksempel på virkestoff - Oksykodon"
 * category.coding.system = "http://terminology.hl7.org/CodeSystem/substance-category"
 * category.coding.code = #drug
 * category.coding.display = "Drug or Medicament"
-
-Instance: Virkestoff-Natriumklorid
-InstanceOf: Virkestoff
-Description: "Eksempel på virkestoff - Natriumklorid"
-* code.coding.system = "http://snomed.info/sct"
-* code.coding.code = #387390002
-* code.coding.display = "Sodium chloride (substance)"
-* category.coding.system = "http://terminology.hl7.org/CodeSystem/substance-category"
-* category.coding.code = #drug
-* category.coding.display = "Drug or Medicament"


### PR DESCRIPTION
## Hva

### Binding fjernet fra `extension:mengde`

Bindingen mot `http://hl7.org/fhir/ValueSet/medication-ingredientstrength` lot seg ikke resolve i en R4-IG. IG Publisher rendret derfor `Binding: medication-ingredientstrength (??) (preferred)` uten lenke, og QA ga «ValueSet ... not found».

Kodeverk anbefales nå i `^comment` på `value[x]` i stedet for via binding. Det er samme mønster som IG-en allerede bruker for Volven-kodeverk — `form.coding[OID7448]` har ingen binding, bare fastsatt `system` og forklarende `^short`/`^comment`.

Bindingen lå dessuten på `value[x]`, som tillater både `CodeableConcept` og `Quantity`. En binding der gjelder begge grenene, og på en `Quantity` styrer den enhetskoden — den bandt altså i praksis `mL` og `mg` mot et qs/trace-kodeverk.

### Beskrivelsen delt opp per datatype

`Description` på extensionen er delt i et avsnitt for `Quantity` og et for `CodeableConcept`, med anbefalte kodeverk for det kodede tilfellet: «Angi at bestanddel i legemiddelblanding ikke har eksakt mengde» (OID 7502) og `medication-ingredientstrength`. Engelsk oversettelse er oppdatert tilsvarende.

### Saltvann i smerteblandingen

`Virkestoff-Natriumklorid` var modellert som `Substance`, men er et legemiddel — og eksempelet viste tørt natriumklorid, ikke sterilt saltvann. Erstattet med `Legemiddel-NatriumkloridBBraun` («Natriumklorid B. Braun oppl væske til parenteral bruk 9 mg/ml», FEST legemiddelmerkevare-id, ATC V07AB).

Beskrivelsen av `Legemiddel-Smerteblanding` sa «de tre måtene å angi en ingrediens på». Rettet til det eksempelet faktisk viser: de tre måtene å angi `strength` på — Ratio, Quantity (mL) og CodeableConcept (qs), altså R5-ens `strength[x]`.

## Verifisert

- `sushi .`: 0 feil. De 2 advarslene er preeksisterende og urelaterte (filtyper i `input/pagecontent`, `menu.xml` vs. `sushi-config.yaml`).
- Generert `StructureDefinition-lmdi-ingredient-strength.json` har ingen `binding` igjen; `Extension.value[x]` har `comment` med `_comment`-oversettelse.
- `Medication-Legemiddel-Smerteblanding.json`: `ingredient[0]` Ratio, `ingredient[1]` `valueQuantity`, `ingredient[2]` `valueCodeableConcept`.
- `Virkestoff-Natriumklorid` var kun referert fra smerteblandingen. `Virkestoff-Oksykodon` står igjen som eksempel på profilen.

## Ikke verifisert

- FEST-id-en er hentet fra Felleskatalogens FEST-merkevareregister, ikke slått opp i FEST direkte.
- At `(??)` forsvinner i rendret HTML følger av at bindingen er borte, men er ikke bekreftet med en IG Publisher-kjøring.
- At den nye flerparagraf-beskrivelsen overlever substring-erstatningen i `lag-en-doklag.py`.
- `sjekk-oversettelser.py` flagger `Extension.definition`, men det er en falsk positiv: heuristikken slår ut på «ikke» i det norske kodeverksnavnet, som med vilje står uoversatt i den engelske teksten.

## Gjenstår

- Oppdatering av `lmdi-fhir`-skillen i `Fhi.Lmr.AI` (eget repo).
- Eventuell linje i versjonsloggen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
