### PR TITLE
Fiks oversettelsessjekk og rydd opp i byggkonfigurasjon

### DIFF
--- a/LMDI/input/fsh/extensions/lmdi-ext-ingredient-strength.fsh
+++ b/LMDI/input/fsh/extensions/lmdi-ext-ingredient-strength.fsh
@@ -30,7 +30,7 @@ Amount of the ingredient in the requested/administered medication, expressed as 
 
 For Quantity: Either the amount of active ingredient in the requested/administered medication (e.g. 100 mg), or the volume of the ingredient used to produce the requested/administered medication (e.g. 10 mL). When volume is used, ingredient.item shall specify the “starting medication” used to produce the requested/administered medication in such a way that the strength of the “starting medication” can be derived. This is necessary to calculate the amount of active ingredient and the strength of the ingredient in the requested/administered medication.
 
-For CodeableConcept: A coded value specifying the amount of the ingredient, e.g. qs or trace. For example from the code system "Angi at bestanddel i legemiddelblanding ikke har eksakt mengde" (OID 7502) or "Medication-ingredientstrength" http://hl7.org/fhir/CodeSystem/medication-ingredientstrength
+For CodeableConcept: A coded value specifying the amount of the ingredient, e.g. qs or trace. For example from the Norwegian code system for components of a medication mixture without an exact amount (OID 7502), or "Medication-ingredientstrength" http://hl7.org/fhir/CodeSystem/medication-ingredientstrength
 """
 * value[x] only CodeableConcept or Quantity
 // Kodeverk anbefales i comment framfor binding: value[x] har to tillatte typer, så det finnes

--- a/LMDI/input/ignoreWarnings.txt
+++ b/LMDI/input/ignoreWarnings.txt
@@ -13,7 +13,3 @@ Value set 'urn:iso:std:iso:3166' .* not found
 Value set 'urn:oid:2.16.578.1.12.4.1.1.9060' .* not found
 Value set 'urn:oid:2.16.578.1.12.4.1.1.7704' .* not found
 Value set 'urn:oid:2.16.578.1.12.4.1.1.7426' .* not found
-# Kodeverket for kodet mengde ingrediens (qs, trace) er definert i R5 og finnes ikke i R4.
-# Bindingen på lmdi-ingredient-strength er preferred og dokumenterer hvilke koder som gjelder.
-A definition could not be found for Canonical URL 'http://hl7.org/fhir/ValueSet/medication-ingredientstrength'
-ValueSet 'http://hl7.org/fhir/ValueSet/medication-ingredientstrength' not found

--- a/LMDI/sushi-config.yaml
+++ b/LMDI/sushi-config.yaml
@@ -48,8 +48,8 @@ parameters:
     - Substance/*
     - Bundle/*
 dependencies:
-  hl7.fhir.uv.extensions.r4: "5.2.0"
-  hl7.fhir.no.basis: "2.2.0"
+  hl7.fhir.uv.extensions.r4: 5.2.0
+  hl7.fhir.no.basis: 2.2.0
 
 
 pages:


### PR DESCRIPTION
## 1. Publiseringsbygget feilet på `sjekk-oversettelser.py`

Etter #109 feilet publiseringen på `main`:

```
=== A) MANGLER ANVENDBAR OVERSETTELSE: 1 felt ===
  StructureDefinition-lmdi-ingredient-strength.json | Extension.definition: ...
##[error]Process completed with exit code 1.
```

Oversettelsen fungerte faktisk — `lag-en-doklag.py` erstattet description-blokken på 16 av 16 StructureDefinition-sider. Men norsk-heuristikken slo ut på ordet **«ikke»**, som står i kodeverksnavnet «Angi at bestanddel i legemiddelblanding ikke har eksakt mengde» — bevisst uoversatt inne i den *engelske* teksten.

Skriptet har strengt tatt rett: en norsk frase blir stående norsk i `/en/`. Det var tilsiktet, men skriptet kan ikke skille tilsiktet fra uteglemt.

**Løsning:** kodeverket beskrives på engelsk og identifiseres med OID i den engelske teksten. Navnet oversettes ikke — det utelates på engelsk, og OID-en identifiserer kodeverket entydig. Den norske beskrivelsen er uendret og beholder det offisielle navnet.

## 2. Anførselstegn i `dependencies`

IG Publisher sin forhåndsinstallasjon leser `sushi-config.yaml` med en enkel tekstparser som drar anførselstegnene med inn i pakkekoordinatet:

```
Unable to install hl7.fhir.uv.extensions.r4#"5.2.0": Invalid criteria: null.x
Unable to install hl7.fhir.no.basis#"2.2.0": Invalid criteria: null.x
```

Semver kveles på det ledende `"`. Bygget gikk videre («Trying to go on») og SUSHI lastet pakkene selv, så dette feilet ingenting — men det er en reell feil i konfigurasjonen.

## 3. Foreldede QA-undertrykkinger

`ignoreWarnings.txt` undertrykte to meldinger om `ValueSet/medication-ingredientstrength`. Bindingen ble fjernet i #109, og URL-en finnes ikke lenger i noen generert ressurs — kommentaren beskrev en binding som ikke eksisterer.

CodeSystem-URL-en er fortsatt i bruk via `$IngrediensStyrkeKoder#qs` i smerteblanding-eksempelet, og den var aldri undertrykt her. Den delen er urørt.

## Verifisert

- `python scripts/sjekk-oversettelser.py`: 0 mangler, **exit 0** — samme kommando som feilet i CI.
- `sushi .`: 0 feil (de 2 advarslene er preeksisterende: filtyper i `input/pagecontent` og `menu.xml` vs. `sushi-config.yaml`).
- **Anførselstegnene er verifisert byte-eksakt:** baseline av `ImplementationGuide-hl7.fhir.no.lmdi.json` tatt før endringen, `sushi .` kjørt etterpå, `diff` sier identisk. SUSHI leste allerede `"5.2.0"` som strengen `5.2.0`, så generert output kan ikke endre seg.
- Begge konsumentene av `sushi-config.yaml` tåler begge former: workflow-ens `sed -E '... "?([0-9]+\.[0-9]+\.[0-9]+)"? ...'` har anførselstegnene valgfrie (testet, gir fortsatt `2.2.0`), og `ByggIG.bat:553` stripper dem eksplisitt.
- `grep` bekrefter at `ValueSet/medication-ingredientstrength` er borte fra hele `fsh-generated/`, mens `CodeSystem/...` fortsatt finnes i tre ressurser.

## Ikke berørt

QA-tallene fra bygget (`Errors: 154, Warnings: 256, Broken Links: 3`) er ikke rørt her. De er verdt en egen gjennomgang, med tre forbehold:

- Terminologisesjonen mot `tx.fhir.org` utløp under den 24:46 lange valideringen (`The cache '05d9cb04-…' … has expired or been released`), så en ukjent andel av feilene er trolig transiente.
- De ~100 «Internal error in location»-meldingene om et `<script>` med `breadcrumb`/`pageData` treffer nesten hver side uniformt — én årsak i `ig-template-fhi`, ikke 100 defekter.
- Den publiserte `qa.html` er fra 12. juni 2026 (v1.1.2), siden gh-pages-steget aldri kjørte. Det finnes altså ingen fersk QA-artefakt å analysere ennå.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
