### PR TITLE
Bump til 1.1.4 og rett avvik i README-tabellen

### DIFF
--- a/LMDI/input/pagecontent/en-index.md
+++ b/LMDI/input/pagecontent/en-index.md
@@ -33,6 +33,7 @@ This provides consistent handling of Norwegian identifiers and code systems acro
 
 | Version | Date | Description |
 |---------|------|-------------|
+| 1.1.4 | 2026-08-21 | New extension Amount of ingredient on `Medication.ingredient.strength`, providing the R5/R6 variants Quantity and CodeableConcept in R4. |
 | 1.1.3 | 2026-08-14 | MedicationRequest: `requester` is no longer mandatory (1..1 → 0..1). The field is still Must Support and shall be provided when the requester is known. |
 | 1.1.2 | 2026-06-12 | Episode: the nprEpisodeIdentifier extension can now be repeated (0..1 → 0..*), allowing multiple NPR identifiers to be provided for the same episode. |
 | 1.1.1 | 2026-05-29 | Added an English translation of the implementation guide. The translation was produced using AI and has so far undergone only limited human quality assurance. |

--- a/LMDI/input/pagecontent/index.md
+++ b/LMDI/input/pagecontent/index.md
@@ -33,6 +33,7 @@ Dette gir en konsistent håndtering av norske identifikatorer og kodeverk på tv
 
 | Versjon | Dato | Beskrivelse |
 |---------|------|-------------|
+| 1.1.4 | 2026-08-21 | Ny extension Mengde ingrediens på `Medication.ingredient.strength`, som gir R5/R6-variantene Quantity og CodeableConcept i R4. |
 | 1.1.3 | 2026-08-14 | Legemiddelrekvirering: `requester` er ikke lenger påkrevd (1..1 → 0..1). Feltet er fortsatt Must Support og skal oppgis når rekvirenten er kjent. |
 | 1.1.2 | 2026-06-12 | Episode: nprEpisodeIdentifier-extensionen kan nå gjentas (0..1 → 0..*), slik at flere NPR-identifikatorer kan oppgis for samme episode. |
 | 1.1.1 | 2026-05-29 | Lagt til engelsk oversettelse av implementasjonsguiden. Oversettelsen er laget med KI og foreløpig kun begrenset kvalitetssikret av mennesker. |

--- a/LMDI/sushi-config.yaml
+++ b/LMDI/sushi-config.yaml
@@ -9,9 +9,9 @@ title: "Legemiddeldata fra institusjon til Legemiddelregisteret"
 description: "Denne implementasjongguiden beskriver hvordan institusjoner skal overføre data om legemiddelbruk i institusjoner til Legemiddelregisteret"
 status: active
 license: CC-BY-4.0
-date: 2026-08-14
+date: 2026-08-21
 language: no
-version: 1.1.3
+version: 1.1.4
 
 fhirVersion: 4.0.1
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ pilotering og innføring hos institusjonene.
 
 | Versjon | Dato | Kort beskrivelse |
 |---------|------|------------------|
+| 1.1.4 | 2026-08-21 | Ny extension Mengde ingrediens på Legemiddel.ingredient.strength |
 | 1.1.3 | 2026-08-14 | Gjort `requester` frivillig i Legemiddelrekvirering, men fortsatt Must Support |
+| 1.1.2 | 2026-06-12 | Flere NPR-identifikatorer tillatt per episode |
 | 1.1.1 | 2026-05-29 | Lagt til engelsk oversettelse av IG-en (laget med KI, foreløpig begrenset kvalitetssikret) |
-| 1.1.0 | 2026-03-27 | Rettet NamingSystem-URL fra fh.no til fhi.no; rettet skrivefeil lokaltVirkemiddel til lokaltLegemiddel |
+| 1.1.0 | 2026-04-13 | Rettet NamingSystem-URL fra fh.no til fhi.no; rettet skrivefeil lokaltVirkemiddel til lokaltLegemiddel |
 | 1.0.8 | 2026-03-10 | Forbedret FSH-eksempler, nye Bundle-eksempler, Virkestoff tillatt i LegemiddelregisterBundle |
 | 1.0.7 | 2025-09-30 | Oppdateringer av adresser og extensions i Pasient og Organisasjon |
 | 1.0.6 | 2025-09-12 | Helsepersonell, Organisasjon, Pasient og Virkestoff basert på no-basis |


### PR DESCRIPTION
## Bakgrunn

Mengde ingrediens-extensionen kom inn i #106 uten versjonsbump, og #108 og #109 bygget videre på samme versjon. `sushi-config.yaml` har stått på `version: 1.1.3` / `date: 2026-08-14` siden `requester`-arbeidet, så en ny profilendring ligger publisert under en versjon som i loggen bare beskriver `requester`.

## Endring

Bump til **1.1.4**, datert 2026-08-21. Ny rad i alle tre versjonstabellene:

> Ny extension Mengde ingrediens på `Medication.ingredient.strength`, som gir R5/R6-variantene Quantity og CodeableConcept i R4.

Versjonen handler kun om den nye extensionen. Eksempel- og dokumentasjonsendringene i #107–#109 er ikke egne logglinjer.

Endringen er verken payload-breaking eller tooling-breaking: en ny valgfri extension (`0..1`) gjør ingen eksisterende innsending ugyldig, og ingen kardinalitet er strammet inn.

## Rettelser i README-tabellen

To preeksisterende avvik, funnet mens tabellene ble sammenlignet:

- **1.1.2 manglet helt.** Finnes i `index.md` og `en-index.md`, aldri lagt inn i README.
- **1.1.0 var datert 2026-03-27.** De to andre tabellene sier 2026-04-13. Sporet i historikken: `bc55907ea` (2026-03-27) bumpet versjonen og skrev README-raden; `1efa921f7` (2026-04-13) skrev om 1.1.0-beskrivelsen med breaking changes, men rørte bare `index.md`. README ble stående med bump-datoen. Rettet til 2026-04-13 for å samsvare med de andre tabellene.

## Verifisert

- `sushi .`: 0 feil (de 2 advarslene er preeksisterende og urelaterte)
- Generert `ImplementationGuide-hl7.fhir.no.lmdi.json`: `version: 1.1.4`, `date: 2026-08-21`
- `python scripts/sjekk-oversettelser.py`: 0 mangler, exit 0
- Alle fire diffene lest igjennom manuelt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
