### PR TITLE
Rett utdatert skill-notat i CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,8 +112,8 @@ cp -r ./node_modules/hl7.fhir.no.basis/* ~/.fhir/packages/hl7.fhir.no.basis#2.2.
 **Viktig ved arbeid med skill-filer:**
 - Sjekk at skill-filene er oppdatert med siste FSH-endringer før bruk (se proveniens-tabellen i `UPDATE.md`)
 - Oppdatering av skillen gjøres etter prosedyren i `C:\dev\Fhi.Lmr.AI\skills\lmdi-fhir\UPDATE.md`
-- Endringer i skill-filer må committes og pushes i `Fhi.Lmr.AI`
-- `.claude/skills/` er lagt til i `.gitignore` og trackes ikke her. Symlinken `.claude/skills/lmdi-fhir` peker fortsatt på den utgåtte plasseringen i `Fhi.Legemiddelregisteret.wiki` og virker ikke — bruk stien over.
+- Endringer i skill-filer må committes og pushes i `Fhi.Lmr.AI`. Push til `main` trigger `azure-pipelines.yml`, som speiler til GitHub (`FHIDev/Fhi.Legemiddelregisteret.AI`) — kilden marketplacen `fhi-lmr` leser fra. Etter speiling må begge lag hentes lokalt: `claude plugin marketplace update fhi-lmr` og `claude plugin update lmr@fhi-lmr` (marketplace-navnet må være med), deretter restart.
+- `.claude/skills/` er gitignorert og tom. Skillen kommer fra `lmr`-pluginen, ikke fra en lokal symlink — ikke legg noe der.
 
 The project follows Norwegian healthcare data standards and integrates with FEST (Norwegian drug database) identifiers.
 


### PR DESCRIPTION
## Bakgrunn

Notatet om `lmdi-fhir`-skillen i `CLAUDE.md` beskrev et oppsett som ikke lenger stemmer. Det påsto at `.claude/skills/lmdi-fhir` er en brutt symlink til den utgåtte plasseringen i `Fhi.Legemiddelregisteret.wiki`. Katalogen er i dag tom, og skillen distribueres i stedet gjennom `lmr`-pluginen.

Notatet manglet også hvordan en endring i skill-filene faktisk når fram til en lokal Claude Code-installasjon. Uten det stopper endringer lett halvveis: de blir committet i `Fhi.Lmr.AI`, men verken speilet eller hentet inn lokalt, og skillen fortsetter å servere gammelt innhold.

## Endringer

- Fjernet påstanden om den brutte symlinken. Presisert at `.claude/skills/` er gitignorert og tom, at skillen kommer fra `lmr`-pluginen, og at det ikke skal legges noe der.
- Dokumentert hele distribusjonskjeden: push til `main` i `Fhi.Lmr.AI` trigger `azure-pipelines.yml`, som speiler til GitHub (`FHIDev/Fhi.Legemiddelregisteret.AI`) — kilden marketplacen `fhi-lmr` leser fra.
- Lagt til kommandoene for å hente inn endringen lokalt: `claude plugin marketplace update fhi-lmr` og `claude plugin update lmr@fhi-lmr`, deretter restart.

## Tekniske detaljer

Marketplace-navnet må være med i `claude plugin update lmr@fhi-lmr`. Uten kvalifisering feiler kommandoen med `Plugin "lmr" not found`.

Begge lagene må oppdateres, og i rekkefølge. `claude plugin update` alene henter ikke ny marketplace-SHA, så en oppdatering uten `marketplace update` først gir ingen endring.

## Testing

Kjeden er kjørt gjennom i praksis mens dokumentasjonen ble skrevet: endringer i `Fhi.Lmr.AI` ble pushet til Azure DevOps, speilingen verifisert med `git ls-remote` mot GitHub, og begge kommandoene kjørt lokalt. Etterpå ble installert plugin-SHA i `installed_plugins.json` sammenlignet med kilde-HEAD, og cache-innholdet diffet mot kilden.

Endringen berører kun `CLAUDE.md` og påvirker ikke IG-en, FSH-filene eller byggeprosessen.
